### PR TITLE
[Fix] Incomplete tooltips at Security tab

### DIFF
--- a/src/Config/ConfigItem.php
+++ b/src/Config/ConfigItem.php
@@ -424,7 +424,7 @@ class ConfigItem    //NOSONAR
 
     protected function user_jit(mixed $var): array //NOSONAR
     {
-        return array_merge([ConfigItem::FORMEXPLAIN     => htmlspecialchars(__('If enabled samlSSO will create new GLPI users on the fly and assign the properties defined in the samlSSO assignment rules. If disables users that do not have a valid GLPI user will not be able to login into GLPI until a user is manually created.')),
+        return array_merge([ConfigItem::FORMEXPLAIN     => __('If enabled samlSSO will create new GLPI users on the fly and assign the properties defined in the samlSSO assignment rules. If disables users that do not have a valid GLPI user will not be able to login into GLPI until a user is manually created.'),
                             ConfigItem::FORMTITLE     => __('JIT USER CREATION', PLUGIN_NAME),
                             ConfigItem::FIELD         => __function__,
                             ConfigItem::VALIDATOR     => __method__,],
@@ -433,7 +433,7 @@ class ConfigItem    //NOSONAR
 
     protected function security_nameidencrypted(mixed $var): array //NOSONAR
     {
-        return array_merge([ConfigItem::FORMEXPLAIN     => __('If enabled the OneLogin PHPSAML toolkit will encrypt the <samlp:logoutRequest> sent by this SP using the provided SP certificate and private key. This option will be toggled "off" automatically if no, or no valid SP certificate and key is provided.'),
+        return array_merge([ConfigItem::FORMEXPLAIN     => htmlspecialchars(__('If enabled the OneLogin PHPSAML toolkit will encrypt the <samlp:logoutRequest> sent by this SP using the provided SP certificate and private key. This option will be toggled "off" automatically if no, or no valid SP certificate and key is provided.')),
                             ConfigItem::FORMTITLE     => __('ENCRYPT NAMEID', PLUGIN_NAME),
                             ConfigItem::FIELD         => __function__,
                             ConfigItem::VALIDATOR     => __method__,],
@@ -442,7 +442,7 @@ class ConfigItem    //NOSONAR
 
     protected function security_authnrequestssigned(mixed $var): array //NOSONAR
     {
-        return array_merge([ConfigItem::FORMEXPLAIN     => __('If enabled the OneLogin PHPSAML toolkit will sign the <samlp:AuthnRequest> messages send by this SP. The IDP should consult the metadata to get the information required to validate the signatures.'),
+        return array_merge([ConfigItem::FORMEXPLAIN     => htmlspecialchars(__('If enabled the OneLogin PHPSAML toolkit will sign the <samlp:AuthnRequest> messages send by this SP. The IDP should consult the metadata to get the information required to validate the signatures.')),
                             ConfigItem::FORMTITLE     => __('SIGN AUTHN REQUEST', PLUGIN_NAME),
                             ConfigItem::FIELD         => __function__,
                             ConfigItem::VALIDATOR     => __method__,],
@@ -451,7 +451,7 @@ class ConfigItem    //NOSONAR
 
     protected function security_logoutrequestsigned(mixed $var): array //NOSONAR
     {
-        return array_merge([ConfigItem::FORMEXPLAIN     => __('If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutRequest> messages send by this SP.'),
+        return array_merge([ConfigItem::FORMEXPLAIN     => htmlspecialchars(__('If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutRequest> messages send by this SP.')),
                             ConfigItem::FORMTITLE     => __('SIGN LOGOUT REQUEST', PLUGIN_NAME),
                             ConfigItem::FIELD         => __function__,
                             ConfigItem::VALIDATOR     => __method__,],
@@ -460,7 +460,7 @@ class ConfigItem    //NOSONAR
 
     protected function security_logoutresponsesigned(mixed $var): array //NOSONAR
     {
-        return array_merge([ConfigItem::FORMEXPLAIN     => __('If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutResponse> messages send by this SP.'),
+        return array_merge([ConfigItem::FORMEXPLAIN     => htmlspecialchars(__('If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutResponse> messages send by this SP.')),
                             ConfigItem::FORMTITLE     => __('SIGN LOGOUT RESPONSE', PLUGIN_NAME),
                             ConfigItem::FIELD         => __function__,
                             ConfigItem::VALIDATOR     => __method__,],


### PR DESCRIPTION
Hello,
The ``ENCRYPT NAMEID`` tooltip at the **Security** tab seems to use an unescaped HTML tag. So it doesn't display the full tooltip text, as can be seen below:

Before this PR:

<img width="1667" height="474" alt="Image" src="https://github.com/user-attachments/assets/5041a094-fc58-4875-a18e-9483830f7a14" />

After this PR:

<img width="585" height="275" alt="image" src="https://github.com/user-attachments/assets/e4506155-8679-4cc1-b321-1d0c8a78b6bf" />