### PR TITLE
Rely user validation on Session::init & Check if user has a profile assigned after user creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/LoginFlow.php
+++ b/src/LoginFlow.php
@@ -428,6 +428,8 @@ class LoginFlow extends CommonDBTM
      */
     protected function performGlpiLogin(Response $response, LoginState $state): void
     {
+        global $CFG_GLPI;
+
         // Push the state into this objects property just in case.
         $this->state = $state;
         

--- a/src/LoginFlow.php
+++ b/src/LoginFlow.php
@@ -647,8 +647,6 @@ class LoginFlow extends CommonDBTM
         echo TemplateRenderer::getInstance()->render('@samlsso/errorScreen.html.twig',  $tplVars);
         // print footer
         Html::nullFooter();
-
-        throw new BadRequestHttpException();
         
         // Make sure php execution is stopped.
         exit;

--- a/src/LoginFlow.php
+++ b/src/LoginFlow.php
@@ -358,8 +358,6 @@ class LoginFlow extends CommonDBTM
      */
     protected function performSamlIdpRequest(): void
     {
-        global $CFG_GLPI;
-        
         // Fetch the correct configEntity GLPI
         if($configEntity = new ConfigEntity($this->state->getIdpId())){ // Get the configEntity object using our stored ID
             $samlConfig = $configEntity->getPhpSamlConfig();      // Get the correctly formatted SamlConfig array

--- a/src/LoginFlow.php
+++ b/src/LoginFlow.php
@@ -598,15 +598,15 @@ class LoginFlow extends CommonDBTM
         $tplVars['error']       = htmlentities((string) $errorMsg);
         $tplVars['returnPath']  = $CFG_GLPI["url_base"] .'/';
         $tplVars['returnLabel'] = __('Return to GLPI', PLUGIN_NAME);
+        
         // print header
+        http_response_code(403); // AccessDeniedHttpException
         Html::nullHeader("Login",  $CFG_GLPI["url_base"] . '/');
         // Render twig template
         // https://codeberg.org/QuinQuies/glpisaml/issues/12
         echo TemplateRenderer::getInstance()->render('@samlsso/loginError.html.twig',  $tplVars);
         // print footer
         Html::nullFooter();
-
-        throw new AccessDeniedHttpException();
 
         // Make sure php execution is stopped.
         exit;
@@ -641,6 +641,7 @@ class LoginFlow extends CommonDBTM
         $tplVars['returnPath']  = $CFG_GLPI["url_base"] .'/';
         $tplVars['returnLabel'] = __('Return to GLPI', PLUGIN_NAME);
         // print header
+        http_response_code(400); // BadRequestHttpException
         Html::nullHeader("Login",  $CFG_GLPI["url_base"] . '/');
         // Render twig template
         echo TemplateRenderer::getInstance()->render('@samlsso/errorScreen.html.twig',  $tplVars);

--- a/src/LoginFlow.php
+++ b/src/LoginFlow.php
@@ -598,7 +598,7 @@ class LoginFlow extends CommonDBTM
         $tplVars['error']       = htmlentities((string) $errorMsg);
         $tplVars['returnPath']  = $CFG_GLPI["url_base"] .'/';
         $tplVars['returnLabel'] = __('Return to GLPI', PLUGIN_NAME);
-        
+
         // print header
         http_response_code(403); // AccessDeniedHttpException
         Html::nullHeader("Login",  $CFG_GLPI["url_base"] . '/');

--- a/src/LoginFlow.php
+++ b/src/LoginFlow.php
@@ -459,6 +459,18 @@ class LoginFlow extends CommonDBTM
         // This tells GLPI a valid GLPI user was logged in.
         Session::init($auth);
 
+        if (!empty($auth->getErrors())) {
+            echo TemplateRenderer::getInstance()->render(
+                    'pages/login_error.html.twig',
+                    [
+                        'errors'    => $auth->getErrors(),
+                        'title'     => __('Access denied'),
+                        'login_url' => $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1&redirect=' . $state->getRedirect(),
+                    ]
+                );
+            exit;
+        }
+
         // Update the samlState table with the new sessionId.
         // so we can keep tracking it after the next redirect.
         // https://github.com/DonutsNL/samlsso/issues/26

--- a/src/LoginFlow.php
+++ b/src/LoginFlow.php
@@ -65,9 +65,6 @@ use GlpiPlugin\Samlsso\Config\ConfigEntity;
 use GlpiPlugin\Samlsso\LoginFlow\User;
 use GlpiPlugin\Samlsso\LoginFlow\Auth as glpiAuth;
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
-use Glpi\Exception\Http\BadRequestHttpException;
-
 /**
  * This object brings it all together. It is responsible to handle the
  * main logic concerned with the Saml login and logout flows.

--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -155,7 +155,7 @@ class User
         // User IS NOT found.
 
             // Try to perform Just In Time (JIT) user creation;
-            $user = $this->performJIT($userFields);
+            return $this->performJIT($userFields);
 
         }else{
         // User is found, check if we are allowed to use it.
@@ -173,16 +173,16 @@ class User
                 LoginFlow::PrintFatalLoginError(__("User with GlpiUserid: ".$user->fields[User::USERID]." is disabled. Please contact your GLPI administrator and request him to
                                             reactivate your account.", PLUGIN_NAME));
             }
-        }
 
-        // Check if the user has any profiles assigned
-        if (count(Profile_User::getForUser($user->fields['id'])) === 0) {
-            LoginFlow::PrintFatalLoginError(__("Your SSO login was successful, but no GLPI Profile was assigned to your account. Please contact your GLPI administrator to assign a profile to your account or create a JIT rule to auto assign a GLPI profile.", PLUGIN_NAME));
-        }
+            // Check if the user has any profiles assigned
+            if (count(Profile_User::getForUser($id)) === 0) {
+                LoginFlow::PrintFatalLoginError(__("Your SSO login was successful but no GLPI profile was assigned to your account. Please contact your GLPI administrator to assign a profile to your account.", PLUGIN_NAME));
+            }
 
-        // User can be used to login, so return the user to the LoginFlow object
-        // for session initialization!.
-        return $user;
+            // User can be used to login, so return the user to the LoginFlow object
+            // for session initialization!.
+            return $user;
+        }
     }
 
     private function performJIT(array $userFields): glpiUser {
@@ -221,6 +221,14 @@ class User
             // Return the freshly created user!
             $user = new glpiUser();
             if($user->getFromDB($id)){
+                // Check if the user has any profiles assigned
+                if (count(Profile_User::getForUser($id)) === 0) {
+                    LoginFlow::PrintFatalLoginError(__("Your SSO login was successful but no GLPI profile was assigned to your account and
+                                                    we failed to assign one dynamically using Just In Time user creation. Please
+                                                    request a GLPI administrator to review the logs and correct the problem or
+                                                    request the administrator to assign a GLPI profile manually.", PLUGIN_NAME));
+                    exit; // Unreachable but prevents linting errors.
+                }
                 Session::addMessageAfterRedirect('Dynamically created GLPI user for:'.$userFields[User::EMAIL]['0']);
                 return $user;
             }else{

--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -221,10 +221,6 @@ class User
             // Return the freshly created user!
             $user = new glpiUser();
             if($user->getFromDB($id)){
-                // Check if the user has any profiles assigned
-                if (count(Profile_User::getForUser($id)) === 0) {
-                    LoginFlow::PrintFatalLoginError(__("Your SSO login was successful and a GLPI user was created, but no GLPI Profile was assigned to your account. Please contact your GLPI administrator to assign a profile to your account or create a JIT rule to auto assign a GLPI profile.", PLUGIN_NAME));
-                }
                 Session::addMessageAfterRedirect('Dynamically created GLPI user for:'.$userFields[User::EMAIL]['0']);
                 return $user;
             }else{

--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -216,6 +216,10 @@ class User
             // Return the freshly created user!
             $user = new glpiUser();
             if($user->getFromDB($id)){
+                // Check if the user has any profiles assigned
+                if (count(Profile_User::getForUser($id)) === 0) {
+                    LoginFlow::PrintFatalLoginError(__("Your SSO login was successful and a GLPI user was created, but no GLPI Profile was assigned to your account. Please contact your GLPI administrator to assign a profile to your account or create a JIT rule to auto assign a GLPI profile.", PLUGIN_NAME));
+                }
                 Session::addMessageAfterRedirect('Dynamically created GLPI user for:'.$userFields[User::EMAIL]['0']);
                 return $user;
             }else{

--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -175,7 +175,7 @@ class User
             }
 
             // Check if the user has any profiles assigned
-            if (count(Profile_User::getForUser($id)) === 0) {
+            if (count(Profile_User::getForUser($user->fields[User::USERID])) === 0) {
                 LoginFlow::PrintFatalLoginError(__("Your SSO login was successful but no GLPI profile was assigned to your account. Please contact your GLPI administrator to assign a profile to your account.", PLUGIN_NAME));
             }
 

--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -155,7 +155,7 @@ class User
         // User IS NOT found.
 
             // Try to perform Just In Time (JIT) user creation;
-            return $this->performJIT($userFields);
+            $user = $this->performJIT($userFields);
 
         }else{
         // User is found, check if we are allowed to use it.
@@ -173,11 +173,16 @@ class User
                 LoginFlow::PrintFatalLoginError(__("User with GlpiUserid: ".$user->fields[User::USERID]." is disabled. Please contact your GLPI administrator and request him to
                                             reactivate your account.", PLUGIN_NAME));
             }
-
-            // User can be used to login, so return the user to the LoginFlow object
-            // for session initialization!.
-            return $user;
         }
+
+        // Check if the user has any profiles assigned
+        if (count(Profile_User::getForUser($user->fields['id'])) === 0) {
+            LoginFlow::PrintFatalLoginError(__("Your SSO login was successful, but no GLPI Profile was assigned to your account. Please contact your GLPI administrator to assign a profile to your account or create a JIT rule to auto assign a GLPI profile.", PLUGIN_NAME));
+        }
+
+        // User can be used to login, so return the user to the LoginFlow object
+        // for session initialization!.
+        return $user;
     }
 
     private function performJIT(array $userFields): glpiUser {


### PR DESCRIPTION
Closes https://github.com/DonutsNL/samlsso/issues/63

``Session::init`` already does some basic validations related to the user, like whether it's active, not deleted, and it also supports due dates ("Valid since" and "Valid until" fields on the User page). This PR checks the ``Session::init`` and displays the default GLPI failed login page (the same one displayed for local user errors) if validation fails.

Now the error requests return an HTTP code and log the IP address of the request to make it easier to block requests using Fail2Ban.