### PR TITLE
Update User.php to fix ENTITY_DEFAULT and PROFILE_DEFAULT variables

### DIFF
--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -317,14 +317,14 @@ class User
             // Do we need to set a specific default entity?
             if(isset($update[User::ENTITY_DEFAULT])){
                 $userDefaults[User::ENTITY_ID] = $update[User::ENTITY_DEFAULT];
-                Toolbox::logInFile(PLUGIN_NAME.PLUGIN_SAMLSSO_LOGEVENTS, __('JIT found default entityID:'.$update[User::GROUP_DEFAULT].'for userId:'.$update['users_id']."\n"));
+                Toolbox::logInFile(PLUGIN_NAME.PLUGIN_SAMLSSO_LOGEVENTS, __('JIT found default entityID:'.$update[User::ENTITY_DEFAULT].'for userId:'.$update['users_id']."\n"));
             }else{
                 Toolbox::logInFile(PLUGIN_NAME.PLUGIN_SAMLSSO_LOGEVENTS, __('Jit didnt find a default EntityId to assign, skipping'."\n"));
             }
             // Do we need to set a specific profile?
             if(isset($update[User::PROFILE_DEFAULT])){
                 $userDefaults[User::PROFILESID] = $update[User::PROFILE_DEFAULT];
-                Toolbox::logInFile(PLUGIN_NAME.PLUGIN_SAMLSSO_LOGEVENTS, __('JIT found default profileID:'.$update[User::GROUP_DEFAULT].'for userId:'.$update['users_id']."\n"));
+                Toolbox::logInFile(PLUGIN_NAME.PLUGIN_SAMLSSO_LOGEVENTS, __('JIT found default profileID:'.$update[User::PROFILE_DEFAULT].'for userId:'.$update['users_id']."\n"));
             }else{
                 Toolbox::logInFile(PLUGIN_NAME.PLUGIN_SAMLSSO_LOGEVENTS, __('Jit didnt find a default ProfileId to assign, skipping'."\n"));
             }


### PR DESCRIPTION
Fixes the PHP error:

```
glpi.WARNING:   *** Warning: Undefined array key "specific_groups_id" at User.php line 345
  Backtrace :
  .../marketplace/samlsso/src/LoginFlow/User.php:345 
  /var/glpi/marketplace/samlsso/hook.php:70          GlpiPlugin\Samlsso\LoginFlow\User->updateUserRights()
  ./src/Plugin.php:1820                              updateUser()
  ./src/Rule.php:1494                                Plugin::doHook()
  ./src/RuleCollection.php:1543                      Rule->process()
  .../marketplace/samlsso/src/LoginFlow/User.php:218 RuleCollection->processAllRules()
  .../marketplace/samlsso/src/LoginFlow/User.php:158 GlpiPlugin\Samlsso\LoginFlow\User->performJIT()
  ...i/marketplace/samlsso/src/LoginFlow/Auth.php:65 GlpiPlugin\Samlsso\LoginFlow\User->getOrCreateUser()
  .../glpi/marketplace/samlsso/src/LoginFlow.php:441 GlpiPlugin\Samlsso\LoginFlow\Auth->loadUser()
  ...i/marketplace/samlsso/src/LoginFlow/Acs.php:290 GlpiPlugin\Samlsso\LoginFlow->performGlpiLogin()
  ...i/marketplace/samlsso/src/LoginFlow/Acs.php:198 GlpiPlugin\Samlsso\LoginFlow\Acs->assertSaml()
  ...samlsso/src/Controller/SamlSsoController.php:73 GlpiPlugin\Samlsso\LoginFlow\Acs->init()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    GlpiPlugin\Samlsso\Controller\SamlSsoController->acs()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```

when importing a user without an entity assigned (see #63).