### PR TITLE
Fixes enforce option to correctly hide the default login form

### DIFF
--- a/templates/loginScreen.html.twig
+++ b/templates/loginScreen.html.twig
@@ -24,14 +24,11 @@
     </div>
 </div>
 {% endif %}
-<!-- Add CSS to hide certain login buttons
-     Will be used as configurable option in 
-     version 1.2.0
+{#
+    CSS to hide default login form, if configuration option enforced is set to true
+#}
 {% if enforced == true %}
 <style>
-    .mb-4:has(#login_password){ display:none; }
-    .mb-2:has(#login_remember){ display:none; }
-    .mb-3:has(.select2){ display:none; }
+    .col-md-5:has(#login_name,#login_password) { display: none; }
 </style>
 {% endif %}
--->

--- a/templates/loginScreen.html.twig
+++ b/templates/loginScreen.html.twig
@@ -24,9 +24,7 @@
     </div>
 </div>
 {% endif %}
-{#
-    CSS to hide default login form, if configuration option enforced is set to true
-#}
+{# CSS to hide default login form, if configuration option enforced is set to true #}
 {% if enforced == true %}
 <style>
     .col-md-5:has(#login_name,#login_password) { display: none; }

--- a/templates/loginScreen.html.twig
+++ b/templates/loginScreen.html.twig
@@ -16,7 +16,7 @@
                 </div>
             </button>
         </div>
-        <!-- This section should never be reached -->
+        {# This section should never be reached #}
         {% else %}
             <div><p>{{ noconfig }}</p>
         {% endfor %}


### PR DESCRIPTION
Fixes #85 

Change results in following login form, if a samlSSO is configured and option "Enforce" is set to true/on.

<img width="995" height="608" alt="image" src="https://github.com/user-attachments/assets/7e6d6949-b0ea-4dd4-a06c-eb69d0761c1d" />
