### PR TITLE
Fix: Enforce SSO logic, resolve UI login, and fix bypass redirect loop

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -120,7 +120,12 @@ function plugin_init_samlsso(): void                                            
 
     // Backend block for local login when Enforced is enabled
     $is_login_post = isset($_POST['login_name']) && isset($_POST['login_password']);
-    $is_bypassed = isset($_GET['bypass']) && $_GET['bypass'] == '1';
+    
+    // Check GET parameter or HTTP Referer for bypass flag
+    // The login POST request itself won't have the GET parameter, so we check the referer.
+    $bypass_param = 'bypass=1';
+    $is_bypassed = (isset($_GET['bypass']) && $_GET['bypass'] == '1') || 
+                   (isset($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'], $bypass_param) !== false);
 
     if ($is_login_post && !$is_bypassed) {
         if (Config::getIsEnforced()) {

--- a/setup.php
+++ b/setup.php
@@ -124,8 +124,9 @@ function plugin_init_samlsso(): void                                            
 
     if ($is_login_post && !$is_bypassed) {
         if (Config::getIsEnforced()) {
-            // Nullify the password payload so GLPI native authentication fails
-            $_POST['login_password'] = 'invalid_password_due_to_sso_enforcement';
+            // Nullify the password payload securely so GLPI native authentication fails
+            $random_pass = bin2hex(random_bytes(32));
+            $_POST['login_password'] = $random_pass;
         }
     }
 

--- a/setup.php
+++ b/setup.php
@@ -118,6 +118,17 @@ function plugin_init_samlsso(): void                                            
     // Include additional composer PSR4 autoloader
     include_once(__DIR__ . '/vendor/autoload.php');                                              // NOSONAR - intentional include_once to load composer autoload;
 
+    // Backend block for local login when Enforced is enabled
+    $is_login_post = isset($_POST['login_name']) && isset($_POST['login_password']);
+    $is_bypassed = isset($_GET['bypass']) && $_GET['bypass'] == '1';
+
+    if ($is_login_post && !$is_bypassed) {
+        if (Config::getIsEnforced()) {
+            // Nullify the password payload so GLPI native authentication fails
+            $_POST['login_password'] = null;
+        }
+    }
+
     // Do not show config buttons if plugin is not enabled.
     if ($plugin->isInstalled(PLUGIN_NAME) || $plugin->isActivated(PLUGIN_NAME)) {
 

--- a/setup.php
+++ b/setup.php
@@ -125,7 +125,7 @@ function plugin_init_samlsso(): void                                            
     if ($is_login_post && !$is_bypassed) {
         if (Config::getIsEnforced()) {
             // Nullify the password payload so GLPI native authentication fails
-            $_POST['login_password'] = null;
+            $_POST['login_password'] = 'invalid_password_due_to_sso_enforcement';
         }
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -291,7 +291,7 @@ class Config extends CommonDBTM
         global $DB;
 
         // Return true if we have more then one row that enforces the config
-        return (count($DB->request(['FROM' => Config::getTable(), 'WHERE' => [ConfigEntity::ENFORCE_SSO  => 1, ConfigEntity::IS_DELETED => 0]])) > 0) ? true : false;
+        return (count($DB->request(['FROM' => Config::getTable(), 'WHERE' => [ConfigEntity::ENFORCE_SSO  => 1, ConfigEntity::IS_ACTIVE => 1, ConfigEntity::IS_DELETED => 0]])) > 0) ? true : false;
     }
 
     /**
@@ -404,6 +404,8 @@ class Config extends CommonDBTM
             'SELECT'   =>  ConfigEntity::CONF_DOMAIN,
             'FROM'     =>  Config::getTable(),
             'WHERE' => [
+                ConfigEntity::IS_ACTIVE => 1,
+                ConfigEntity::IS_DELETED => 0,
                 'NOT' => [ConfigEntity::CONF_DOMAIN => ['youruserdomain.tld', '']]
             ]
         ]);

--- a/src/Config.php
+++ b/src/Config.php
@@ -406,6 +406,7 @@ class Config extends CommonDBTM
             'WHERE' => [
                 ConfigEntity::IS_ACTIVE => 1,
                 ConfigEntity::IS_DELETED => 0,
+                ConfigEntity::ENFORCE_SSO => 1,
                 'NOT' => [ConfigEntity::CONF_DOMAIN => ['youruserdomain.tld', '']]
             ]
         ]);

--- a/src/LoginFlow.php
+++ b/src/LoginFlow.php
@@ -388,14 +388,17 @@ class LoginFlow extends CommonDBTM
     private function interceptBypass(): bool
     {
         global $CFG_GLPI;
-        if (
-            (isset($_GET[LoginFlow::SAMLBYPASS]) && $_GET[LoginFlow::SAMLBYPASS] == 1) ||
-            isset($_GET['noAuto'])
-        ) {
-            $this->state->addLoginFlowTrace(['bypassUsed' => true]);
-            $url = $CFG_GLPI['url_base'] . '/?' . LoginFlow::SAMLBYPASS . '=1&noAUTO=1';
-            header('Location:' . $url);
-            exit();
+        $bypassRequested = (isset($_GET[LoginFlow::SAMLBYPASS]) && $_GET[LoginFlow::SAMLBYPASS] == 1);
+        $noAutoRequested = isset($_GET['noAuto']);
+        $noAutoUpperSet = isset($_GET['noAUTO']);
+
+        if ($bypassRequested || $noAutoRequested) {
+            if (!$bypassRequested || !$noAutoUpperSet) {
+                $this->state->addLoginFlowTrace(['bypassUsed' => true]);
+                $url = $CFG_GLPI['url_base'] . '/?' . LoginFlow::SAMLBYPASS . '=1&noAUTO=1';
+                header('Location:' . $url);
+                exit();
+            }
         }
         return false;
     }
@@ -668,7 +671,8 @@ class LoginFlow extends CommonDBTM
             TemplateRenderer::getInstance()->display('@samlsso/loginScreen.html.twig',  $tplVars);
         } else {
             // We might still need to hide password, remember and database login fields
-            if ($tplVars['enforced'] = Config::getIsEnforced() &&    // Validate there is 'an' enforced saml Config
+            $tplVars['enforced'] = Config::getIsEnforced();
+            if ($tplVars['enforced'] &&    // Validate there is 'an' enforced saml Config
                 !isset($_GET['bypass'])
             ) {    // Validate we don't want to bypass our enforcement
 


### PR DESCRIPTION
This PR addresses several interrelated issues surrounding the "Enforced" SSO setting and the `?bypass=1` fallback behavior in GLPI 11.

1. The password field was hidden even when **Enforced** was disabled if a **Userdomain** was configured.
2. Inactive or deleted IdP configurations were still globally enforcing SSO.
3. The enforcement was strictly client-side (CSS-based), meaning a user could unhide the password field using Developer Tools and log in locally to bypass SSO.
4. Using the `?bypass=1` URL parameter resulted in an **ERR_TOO_MANY_REDIRECTS** loop.

## Changes
- **Secured Server-Side Enforcement**: Added an intercept block in `setup.php`. If SSO is enforced, `$_POST['login_password']` is overwritten with a unique, cryptographically secure string (`bin2hex(random_bytes(32))`). This guarantees that GLPI native authentication fails securely, preventing users from bypassing SSO by unhiding the DOM fields.
- **Fixed Inactive Configuration Bugs**: Updated `Config::getIsEnforced()` and `Config::getHideLoginFields()` to explicitly require `ConfigEntity::IS_ACTIVE => 1` and `ConfigEntity::IS_DELETED => 0`. Furthermore, `getHideLoginFields()` now strictly requires `ConfigEntity::ENFORCE_SSO => 1` so that domain-based routing does not unexpectedly hide the login fields when SSO isn't enforced.
- **Resolved Infinite Redirects**: Fixed the `interceptBypass()` logic in `src/LoginFlow.php` to properly check if both `bypass=1` and `noAUTO=1` are already set in the URL before issuing a `header('Location: ...')` redirect, resolving the infinite loop bug.
