### PR TITLE
Refactor: Standardize clipboard copy mechanism in Service Provider tab

### DIFF
--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -616,7 +616,8 @@
                                 'readonly':true,
                                 'is_copyable': true,
                                 'add_field_html': meta_helper,
-                                'wrapper_class': 'flex-nowrap align-items-center',
+                                'inline_add_field_html': true,
+                                'center': true,
                                 helper: __('The location of the metadata provider for this service provider (GLPI). The meta location can be
                                             used by the identity provider to collect important information from this service provider like
                                             what public certificate to use for signing and encrypting the SamlResponse.'),

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -593,7 +593,7 @@
                             {
                                 'id': 'EntityId',
                                 'disabled':true,
-                                'copyable': true,
+                                'is_copyable': true,
                                 helper: __('You need to configure the Entity ID at the identity provider. This value is
                                             crosschecked by the identity provider to make sure the sign-in request is
                                             originating from the correct service provider.'),
@@ -608,7 +608,7 @@
                             {
                                 'id': 'MetaUrl',
                                 'disabled':true,
-                                'copyable': true,
+                                'is_copyable': true,
                                 helper: __('The location of the metadata provider for this service provider (GLPI). The meta location can be
                                             used by the identity provider to collect important information from this service provider like
                                             what public certificate to use for signing and encrypting the SamlResponse.'),
@@ -623,7 +623,7 @@
                             {
                                 'id': 'AcsUrl',
                                 'disabled':true,
-                                'copyable': true,
+                                'is_copyable': true,
                                 helper: __('The location of the Assertion Consumer Service (ACS) for this service provider (GLPI). 
                                             This url is called by the identity provider after succesfull login.'),
                             }
@@ -638,7 +638,7 @@
                             {
                                 'id': 'SloUrl',
                                 'disabled':true,
-                                'copyable': true,
+                                'is_copyable': true,
                                 helper: __('The location where logout requests should be send back to from the Identity Provider.'),
                             }
                         ) }}
@@ -1103,45 +1103,6 @@
             <!-- Claim Mapping details -->
             <div class="tab-pane fade" id="claim_mapping" role="tabpanel" aria-labelledby="claim-mapping-tab">
                 <style>
-                        #phpsaml_config .copy_to_clipboard_wrapper {
-                            display: flex !important;
-                            align-items: stretch !important;
-                        }
-                        #phpsaml_config .copy_to_clipboard_wrapper input {
-                            border-top-right-radius: 0 !important;
-                            border-bottom-right-radius: 0 !important;
-                        }
-                        #phpsaml_config .copy_to_clipboard_wrapper::after {
-                            font-family: 'tabler-icons' !important;
-                            content: "\ea7a" !important; /* ti-copy */
-                            display: flex !important;
-                            align-items: center !important;
-                            padding: 0 0.75rem !important;
-                            background-color: transparent !important;
-                            border: 1px solid var(--bs-border-color) !important;
-                            border-left: 0 !important;
-                            border-top-right-radius: var(--bs-border-radius) !important;
-                            border-bottom-right-radius: var(--bs-border-radius) !important;
-                            color: var(--bs-body-color) !important;
-                            cursor: pointer !important;
-                            font-weight: normal !important;
-                            position: static !important;
-                            left: auto !important;
-                            top: auto !important;
-                            transition: all 0.2s ease-in-out !important;
-                        }
-                        #phpsaml_config .copy_to_clipboard_wrapper:hover::after {
-                            background-color: var(--bs-secondary-bg) !important;
-                        }
-                        #phpsaml_config .copy_to_clipboard_wrapper.copied::after {
-                            content: "\ea5e" !important; /* ti-check */
-                            color: #2fb344 !important; /* tabler success green */
-                        }
-                        #phpsaml_config .copy_to_clipboard_wrapper.copyfail::after {
-                            content: "\eb5e" !important; /* ti-alert-triangle */
-                            color: #d63939 !important; /* tabler danger red */
-                        }
-
                     #xml_highlighted_code { color: #24292e; }
                     .xml-tag { color: #d73a49; font-weight: bold; }
                     .xml-attr { color: #6f42c1; }

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -669,7 +669,7 @@
                                 <div id="textHelper" class="form-text" style="color:red;">{{ inputfields.sp_certificate.errors }}</div>
                             {% endif %}
                             {# make sure validate is an array/object before accessing nested keys #}
-                           {% set sp_validate = inputfields.sp_certificate.validate|default({}) %}
+                            {% set sp_validate = inputfields.sp_certificate.validate|default({}) %}
                             {% if sp_validate.subject.CN|default(false) == true %}
                                 <div id="textHelper" class="form-text" style="color:rgb(71, 180, 8);">🆗 Valid certificate found: {{ sp_validate.subject.CN|default('') }}</div>
                             {% endif %}

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -601,6 +601,12 @@
                         ) }}
 
                         <!-- Meta URL -->
+                        {% set meta_helper %}
+                            {% if inputfields.debug.value == false %}
+                                <span class="form-help ms-2" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="Debug is 
+                                disabled, metadata will only be exposed if 'debug' is enabled.">⚠️</span>
+                            {% endif %}
+                        {% endset %}
                         {{ fields.textField(
                             'MetaUrl', 
                             metaUrl, 
@@ -609,6 +615,7 @@
                                 'id': 'MetaUrl',
                                 'disabled':true,
                                 'is_copyable': true,
+                                'add_field_html': meta_helper,
                                 helper: __('The location of the metadata provider for this service provider (GLPI). The meta location can be
                                             used by the identity provider to collect important information from this service provider like
                                             what public certificate to use for signing and encrypting the SamlResponse.'),

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -605,9 +605,14 @@
                             <div class="btn-group btn-group-sm d-flex">
                                 <input type="text" id="MetaUrl" class="form-control rounded-end-0" name="MetaUrl" value="{{ metaUrl }}" readonly="readonly">
                                 {% if inputfields.debug.value == false %}
-                                    <button type="button" class="btn btn-outline-secondary" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="Debug is disabled, metadata will only be exposed if 'debug' is enabled.">
-                                        <i class="ti ti-alert-triangle text-warning"></i>
+                                    {% set rand = random() %}
+                                    <button type="button" id="meta_warning_{{ rand }}" class="btn btn-outline-secondary">
+                                        <i class="ti ti-alert-triangle"></i>
                                     </button>
+                                    {% do call('Html::showToolTip', [
+                                        "Debug is disabled, metadata will only be exposed if 'debug' is enabled.",
+                                        {'applyto': 'meta_warning_' ~ rand}
+                                    ]) %}
                                 {% endif %}
                                 <button type="button" class="btn btn-outline-secondary" onclick="copyDisclosablePasswordFieldToClipboard('MetaUrl')">
                                     <i class="ti ti-clipboard-copy disclose"></i>

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -592,7 +592,7 @@
                             'Entity ID',
                             {
                                 'id': 'EntityId',
-                                'disabled':true,
+                                'readonly':true,
                                 'is_copyable': true,
                                 helper: __('You need to configure the Entity ID at the identity provider. This value is
                                             crosschecked by the identity provider to make sure the sign-in request is
@@ -603,7 +603,7 @@
                         <!-- Meta URL -->
                         {% set meta_helper %}
                             {% if inputfields.debug.value == false %}
-                                <span class="form-help ms-2" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="Debug is 
+                                <span class="form-help ms-2 mb-0" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="Debug is 
                                 disabled, metadata will only be exposed if 'debug' is enabled.">⚠️</span>
                             {% endif %}
                         {% endset %}
@@ -613,9 +613,10 @@
                             'MetaUrl',
                             {
                                 'id': 'MetaUrl',
-                                'disabled':true,
+                                'readonly':true,
                                 'is_copyable': true,
                                 'add_field_html': meta_helper,
+                                'wrapper_class': 'flex-nowrap align-items-center',
                                 helper: __('The location of the metadata provider for this service provider (GLPI). The meta location can be
                                             used by the identity provider to collect important information from this service provider like
                                             what public certificate to use for signing and encrypting the SamlResponse.'),
@@ -629,7 +630,7 @@
                             'AcsUrl',
                             {
                                 'id': 'AcsUrl',
-                                'disabled':true,
+                                'readonly':true,
                                 'is_copyable': true,
                                 helper: __('The location of the Assertion Consumer Service (ACS) for this service provider (GLPI). 
                                             This url is called by the identity provider after succesfull login.'),
@@ -644,7 +645,7 @@
                             'SloUrl',
                             {
                                 'id': 'SloUrl',
-                                'disabled':true,
+                                'readonly':true,
                                 'is_copyable': true,
                                 helper: __('The location where logout requests should be send back to from the Identity Provider.'),
                             }

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -601,6 +601,9 @@
                         ) }}
 
                         <!-- Meta URL -->
+                        <style>
+                            [data-testid="form-field-MetaUrl"] .btn-group { flex-grow: 1; }
+                        </style>
                         {% set meta_helper %}
                             {% if inputfields.debug.value == false %}
                                 <span class="form-help ms-2 mb-0" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="Debug is 

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -19,18 +19,10 @@
             $('[href="' + lastTab + '"]').tab('show');
         }
     });
-    // Clipboard function
-    function copyClip(key) {
-        // Get the text field
-        var copyText = document.getElementById(key);
-        // Select the text field
-        copyText.select();
-        copyText.setSelectionRange(0, 99999); // For mobile devices
-        // Copy the text inside the text field
-        navigator.clipboard.writeText(copyText.value);
-        // Alert the copied text
-        alert("Succesfully copied the value: " + copyText.value + " to your clipboard.");
-    }
+
+    // Get user id and username
+    const currentUserId = {{ currentUserId|json_encode|raw }};
+    const currentUsername = {{ currentUsername|json_encode|raw }};
     
     var mappingPresets = {{ mapping_presets|json_encode|raw }};
     const allowedUserFields = {{ allowed_user_fields|json_encode|raw }};
@@ -594,9 +586,6 @@
                     <!-- Service provider details -->
                     <div>
                         <!-- Entity ID -->
-                        {% set clipboad %}
-                            <span class='btn btn-ghost-info' onclick="copyClip('EntityId')" onkeydown="copyClip('EntityId')">Copy Entity Id to clipboard</span>
-                        {% endset %}
                         {{ fields.textField(
                             'EntityID', 
                             entityID, 
@@ -604,7 +593,7 @@
                             {
                                 'id': 'EntityId',
                                 'disabled':true,
-                                'add_field_html': clipboad,
+                                'copyable': true,
                                 helper: __('You need to configure the Entity ID at the identity provider. This value is
                                             crosschecked by the identity provider to make sure the sign-in request is
                                             originating from the correct service provider.'),
@@ -612,13 +601,6 @@
                         ) }}
 
                         <!-- Meta URL -->
-                        {% set clipboad %}
-                            <span class='btn btn-ghost-info' onclick="copyClip('MetaUrl')" onkeydown="copyClip('MetaUrl')">Copy Meta Url to clipboard</span>
-                            {% if inputfields.debug.value == false %}
-                                <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="Debug is 
-                                disabled, metadata will only be exposed if 'debug' is enabled.">⚠️</span>
-                            {% endif %}
-                        {% endset %}
                         {{ fields.textField(
                             'MetaUrl', 
                             metaUrl, 
@@ -626,7 +608,7 @@
                             {
                                 'id': 'MetaUrl',
                                 'disabled':true,
-                                'add_field_html': clipboad,
+                                'copyable': true,
                                 helper: __('The location of the metadata provider for this service provider (GLPI). The meta location can be
                                             used by the identity provider to collect important information from this service provider like
                                             what public certificate to use for signing and encrypting the SamlResponse.'),
@@ -634,9 +616,6 @@
                         ) }}
                        
                         <!-- ACS url -->
-                        {% set clipboad %}
-                            <span class='btn btn-ghost-info' onclick="copyClip('AcsUrl')" onkeydown="copyClip('AcsUrl')">Copy ACS Url to clipboard</span>
-                        {% endset %}
                         {{ fields.textField(
                             'AcsUrl', 
                             acsUrl, 
@@ -644,7 +623,7 @@
                             {
                                 'id': 'AcsUrl',
                                 'disabled':true,
-                                'add_field_html': clipboad,
+                                'copyable': true,
                                 helper: __('The location of the Assertion Consumer Service (ACS) for this service provider (GLPI). 
                                             This url is called by the identity provider after succesfull login.'),
                             }
@@ -652,9 +631,6 @@
 
 
                         <!-- Logout url -->
-                        {% set clipboad %}
-                            <span class='btn btn-ghost-info' onclick="copyClip('SloUrl')" onkeydown="copyClip('SloUrl')">Copy logout Url to clipboard</span>
-                        {% endset %}
                         {{ fields.textField(
                             'SloUrl', 
                              sloUrl, 
@@ -662,7 +638,7 @@
                             {
                                 'id': 'SloUrl',
                                 'disabled':true,
-                                'add_field_html': clipboad,
+                                'copyable': true,
                                 helper: __('The location where logout requests should be send back to from the Identity Provider.'),
                             }
                         ) }}
@@ -678,7 +654,7 @@
                                 <div id="textHelper" class="form-text" style="color:red;">{{ inputfields.sp_certificate.errors }}</div>
                             {% endif %}
                             {# make sure validate is an array/object before accessing nested keys #}
-+                           {% set sp_validate = inputfields.sp_certificate.validate|default({}) %}
+                           {% set sp_validate = inputfields.sp_certificate.validate|default({}) %}
                             {% if sp_validate.subject.CN|default(false) == true %}
                                 <div id="textHelper" class="form-text" style="color:rgb(71, 180, 8);">🆗 Valid certificate found: {{ sp_validate.subject.CN|default('') }}</div>
                             {% endif %}
@@ -1127,6 +1103,45 @@
             <!-- Claim Mapping details -->
             <div class="tab-pane fade" id="claim_mapping" role="tabpanel" aria-labelledby="claim-mapping-tab">
                 <style>
+                        #phpsaml_config .copy_to_clipboard_wrapper {
+                            display: flex !important;
+                            align-items: stretch !important;
+                        }
+                        #phpsaml_config .copy_to_clipboard_wrapper input {
+                            border-top-right-radius: 0 !important;
+                            border-bottom-right-radius: 0 !important;
+                        }
+                        #phpsaml_config .copy_to_clipboard_wrapper::after {
+                            font-family: 'tabler-icons' !important;
+                            content: "\ea7a" !important; /* ti-copy */
+                            display: flex !important;
+                            align-items: center !important;
+                            padding: 0 0.75rem !important;
+                            background-color: transparent !important;
+                            border: 1px solid var(--bs-border-color) !important;
+                            border-left: 0 !important;
+                            border-top-right-radius: var(--bs-border-radius) !important;
+                            border-bottom-right-radius: var(--bs-border-radius) !important;
+                            color: var(--bs-body-color) !important;
+                            cursor: pointer !important;
+                            font-weight: normal !important;
+                            position: static !important;
+                            left: auto !important;
+                            top: auto !important;
+                            transition: all 0.2s ease-in-out !important;
+                        }
+                        #phpsaml_config .copy_to_clipboard_wrapper:hover::after {
+                            background-color: var(--bs-secondary-bg) !important;
+                        }
+                        #phpsaml_config .copy_to_clipboard_wrapper.copied::after {
+                            content: "\ea5e" !important; /* ti-check */
+                            color: #2fb344 !important; /* tabler success green */
+                        }
+                        #phpsaml_config .copy_to_clipboard_wrapper.copyfail::after {
+                            content: "\eb5e" !important; /* ti-alert-triangle */
+                            color: #d63939 !important; /* tabler danger red */
+                        }
+
                     #xml_highlighted_code { color: #24292e; }
                     .xml-tag { color: #d73a49; font-weight: bold; }
                     .xml-attr { color: #6f42c1; }

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -605,8 +605,8 @@
                             <div class="btn-group btn-group-sm d-flex">
                                 <input type="text" id="MetaUrl" class="form-control rounded-end-0" name="MetaUrl" value="{{ metaUrl }}" readonly="readonly">
                                 {% if inputfields.debug.value == false %}
-                                    <button type="button" class="btn btn-outline-warning" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Debug is disabled, metadata will only be exposed if 'debug' is enabled.">
-                                        <i class="ti ti-alert-triangle"></i>
+                                    <button type="button" class="btn btn-outline-secondary" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="Debug is disabled, metadata will only be exposed if 'debug' is enabled.">
+                                        <i class="ti ti-alert-triangle text-warning"></i>
                                     </button>
                                 {% endif %}
                                 <button type="button" class="btn btn-outline-secondary" onclick="copyDisclosablePasswordFieldToClipboard('MetaUrl')">

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -601,26 +601,24 @@
                         ) }}
 
                         <!-- Meta URL -->
-                        <style>
-                            [data-testid="form-field-MetaUrl"] .btn-group { flex-grow: 1; }
-                        </style>
-                        {% set meta_helper %}
-                            {% if inputfields.debug.value == false %}
-                                <span class="form-help ms-2 mb-0" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true" data-bs-content="Debug is 
-                                disabled, metadata will only be exposed if 'debug' is enabled.">⚠️</span>
-                            {% endif %}
+                        {% set metaUrl %}
+                            <div class="btn-group btn-group-sm d-flex">
+                                <input type="text" id="MetaUrl" class="form-control rounded-end-0" name="MetaUrl" value="{{ metaUrl }}" readonly="readonly">
+                                {% if inputfields.debug.value == false %}
+                                    <button type="button" class="btn btn-outline-warning" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Debug is disabled, metadata will only be exposed if 'debug' is enabled.">
+                                        <i class="ti ti-alert-triangle"></i>
+                                    </button>
+                                {% endif %}
+                                <button type="button" class="btn btn-outline-secondary" onclick="copyDisclosablePasswordFieldToClipboard('MetaUrl')">
+                                    <i class="ti ti-clipboard-copy disclose"></i>
+                                </button>
+                            </div>
                         {% endset %}
-                        {{ fields.textField(
+                        {{ fields.field(
                             'MetaUrl', 
                             metaUrl, 
                             'MetaUrl',
                             {
-                                'id': 'MetaUrl',
-                                'readonly':true,
-                                'is_copyable': true,
-                                'add_field_html': meta_helper,
-                                'inline_add_field_html': true,
-                                'center': true,
                                 helper: __('The location of the metadata provider for this service provider (GLPI). The meta location can be
                                             used by the identity provider to collect important information from this service provider like
                                             what public certificate to use for signing and encrypting the SamlResponse.'),


### PR DESCRIPTION
## Description
This PR refactors the clipboard copy functionality on the "Service provider" configuration tab to leverage GLPI's native core UI macros, aligning the plugin's styling and functionality with standard GLPI 10+ interfaces.

## Changes Made
- **Removed custom clipboard logic:** Stripped out the manually injected `copyClip()` JavaScript function and custom button HTML elements from `configForm.html.twig`.
- **Implemented native GLPI macros:** Switched to using `is_copyable: true` within the `fields.textField` configuration for the `EntityID`, `MetaUrl`, `AcsUrl`, and `SloUrl` fields. 
- **Standardized UI:** The plugin now natively utilizes standard GLPI button groups (`.btn-group.d-flex`) featuring the `ti-clipboard-copy` icon, matching core GLPI pages (such as `/front/user.form.php`).
- **Retained conditional warnings:** Properly mapped the inline debug warning popover for `MetaUrl` into the `add_field_html` configuration to ensure it renders correctly adjacent to the new input/button group.

## Impact
- **Consistency:** Dramatically improves UI consistency by matching GLPI core design paradigms and Tabler icon usage.
- **Maintainability:** Decreases technical debt by removing custom JavaScript and CSS code in favor of core GLPI functions (`.copy_to_clipboard_wrapper`).