### PR TITLE
Fix: Resolve gettext embedded URL warnings, make `generatePot.sh` POSIX compliant, and add full pt_BR translation

### DIFF
--- a/locales/es_AR.po
+++ b/locales/es_AR.po
@@ -2,108 +2,410 @@
 # Copyright (C) YEAR Chris Gralike
 # This file is distributed under the same license as the samlSSO package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Alan Ivés Lehoux, 2025
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: samlSSO 1.2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/DonutsNL/samlSSO/issues\n"
-"POT-Creation-Date: 2025-11-27 12:28+0100\n"
+"POT-Creation-Date: 2026-05-31 01:33-0300\n"
 "PO-Revision-Date: 2025-11-27 11:38+0000\n"
 "Last-Translator: Alan Ivés Lehoux, 2025\n"
-"Language-Team: Spanish (Argentina) (https://app.transifex.com/quinquies/teams/199875/es_AR/)\n"
+"Language-Team: Spanish (Argentina) (https://app.transifex.com/quinquies/"
+"teams/199875/es_AR/)\n"
+"Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es_AR\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: hook.php:84
+#: hook.php:104
 msgid "samlSSO exclusions"
 msgstr "exclusiones de samlSSO"
 
-#: hook.php:129
+#: hook.php:163
 msgid "🆗 Installing version:"
 msgstr "🆗 Instalando versión:"
 
-#: hook.php:133
+#: hook.php:187
+msgid ""
+"⚠️ PHP memory_limit is less than 512M. This may cause crashes during SAML "
+"Login. See: "
+msgstr ""
+
+#: hook.php:198
 msgid "⚠️ OpenSSL not available, cant verify provided certificates"
 msgstr ""
 "⚠️ OpenSSL no está disponible, no se pueden verificar los certificados "
 "provistos"
 
-#: hook.php:135
+#: hook.php:200
 msgid "🆗 OpenSSL found!"
 msgstr "🆗 ¡OpenSSL encontrado!"
 
-#: setup.php:199
+#: setup.php:227
 msgid "Installed "
 msgstr "Instalado "
 
-#: src/RuleSaml.php:80
-msgid "JIT rules"
-msgstr "Reglas JIT"
-
-#: src/RuleSamlCollection.php:73 src/Config.php:148
+#: src/RuleSamlCollection.php:73 src/Config.php:151
 msgid "JIT import rules"
 msgstr "Reglas de importación JIT"
 
-#: src/CronTask.php:65
-msgid "Clean old SAML sessions"
-msgstr "Limpiar sesiones SAML antiguas"
+#: src/LoginFlow.php:170
+msgid "samlFlow"
+msgstr "samlFlow"
 
-#: src/CronTask.php:66
-msgid "SAML sessions retention period (in days, 0 for infinite)"
-msgstr "Período de retención de sesiones SAML (en días, 0 para infinito)"
+#: src/LoginFlow.php:258
+msgid "You have been forcefully logged out by an administrator."
+msgstr ""
 
-#: src/Config/ConfigItem.php:95 src/LoginFlow/LoginFlowItem.php:90
+#: src/LoginFlow.php:482
+msgid "Could not update the loginState and therefor stopped the loginFlow for:"
+msgstr ""
+"No se pudo actualizar el loginState y, por lo tanto, se detuvo el loginFlow "
+"para:"
+
+#: src/LoginFlow.php:591
+#, php-format
+msgid ""
+"You have been authenticated using the SAML2 identity provider: <b>%1$s</b>."
+"<br><br>Because SAML authentication is enforced, logging out of GLPI locally "
+"will automatically log you back in immediately.<br><br>To sign out "
+"completely, please select <b>'Log out everywhere'</b>. Note that this will "
+"also terminate your active sessions in all other applications connected to "
+"this Identity Provider.<br><br>If you want to leave GLPI, just close this "
+"browser tab."
+msgstr ""
+
+#: src/LoginFlow.php:596
+#, php-format
+msgid ""
+"You have been authenticated using the SAML2 identity provider: <b>%1$s</b>."
+"<br><br>You can log out permanently by also logging out with the IDP by "
+"pressing <b>'Log out everywhere'</b> (which terminates active sessions in "
+"all other applications depending on it), or perform a local logout from GLPI "
+"only by pressing <b>'Continue GLPI logout'</b>."
+msgstr ""
+
+#: src/LoginFlow.php:603
+msgid "🤔 How do you like to proceed?"
+msgstr ""
+
+#: src/LoginFlow.php:606
+#, fuzzy
+msgid "Continue with local logout"
+msgstr "Continuar con el cierre de sesión de GLPI"
+
+#: src/LoginFlow.php:608
+msgid "Close tab"
+msgstr ""
+
+#: src/LoginFlow.php:609
+msgid "Log out everywhere"
+msgstr "Cerrar sesión en todos lados"
+
+#: src/LoginFlow.php:663
+msgid "Login with external provider"
+msgstr "Iniciar sesión con proveedor externo"
+
+#: src/LoginFlow.php:715 src/LoginFlow.php:775
+msgid "An internal error occurred. Please contact your GLPI administrator."
+msgstr ""
+
+#: src/LoginFlow.php:718
+msgid "⚠️ Sorry we are unable to log you in"
+msgstr "⚠️ Lo sentimos, no te podemos iniciar sesión"
+
+#: src/LoginFlow.php:723 src/LoginFlow.php:782
+msgid "Return to GLPI"
+msgstr "Volver a GLPI"
+
+#: src/LoginFlow.php:778
+msgid "⚠️ An error occurred"
+msgstr "⚠️ Ocurrió un error"
+
+#: src/LoginFlow.php:779
+msgid "We are sorry, something went wrong while processing your request!"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:120
+#, fuzzy
+msgid "IDP configuration ID must be a positive integer"
+msgstr "⭕ ¡El ID del IDP debe ser un valor numérico positivo!"
+
+#: src/Config/ClaimMapItem.php:140
+msgid "Invalid mapping target type"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:162
+msgid "Invalid GLPI field selected for target type"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:182
+msgid "SAML Claim key cannot be empty"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:184
+msgid "SAML Claim key cannot exceed 255 characters"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:204
+msgid "Default value must be a string"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:206
+msgid "Default value cannot exceed 255 characters"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:310
+msgid "SAML Claim key cannot be empty for Username mapping."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:318
+msgid "SAML Claim key cannot be empty for Email mapping."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:357
+#, php-format
+msgid "Duplicate mapping for %s: %s"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:373
+msgid "Username mapping is required and cannot be removed."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:377
+msgid "Email mapping is required and cannot be removed."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:480
+msgid "NameId attribute is missing in samlResponse"
+msgstr "El atributo NameId está faltando en la samlResponse"
+
+#: src/Config/ClaimMapEntity.php:486
+msgid ""
+"Detected a default guest user in samlResponse, this is not supported by "
+"glpiSAML."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:531
+msgid ""
+"Warning: SAML NameId format was requested as email but observed value is not "
+"a valid email. Falling back to configured email field."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:554
+msgid "invalid values where used to identify the user during auth"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:616
+#, php-format
+msgid "Required user field \"%s\" is missing or invalid in SAML response"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:658
+msgid "Required rule field \"groups\" is missing in SAML response"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:705
+#, php-format
+msgid "Required rule field \"%s\" is missing or invalid in SAML response"
+msgstr ""
+
+#: src/Config/ConfigEntity.php:364
+msgid ""
+"⚠️ SP private key does not seem to match provided SP certificates modulus."
+msgstr ""
+"⚠️ La clave privada del SP no parece coincidir con el módulo de los "
+"certificados SP proporcionados."
+
+#: src/Config/ConfigEntity.php:369
+msgid ""
+"⚠️ Will be defaulted to \"No\" because the provided SP certificate does not "
+"look valid!"
+msgstr ""
+"⚠️ ¡Se va a establecer \"No\" por defecto porque el certificado SP "
+"proporcionado no parece válido!"
+
+#: src/Config/ConfigEntity.php:417
+msgid "⚠️ IDPs cannot be enforced if more than one is present in the IDP list."
+msgstr ""
+
+#: src/Config/ConfigForm.php:255
+msgid "Restore failed: no valid backup file was uploaded."
+msgstr ""
+
+#: src/Config/ConfigForm.php:261
+msgid "Restore failed: unable to read the uploaded file."
+msgstr ""
+
+#: src/Config/ConfigForm.php:298
+msgid "Restore failed: the backup file has an invalid or unrecognized format."
+msgstr ""
+
+#: src/Config/ConfigForm.php:338
+#, php-format
+msgid "Entry %d skipped: missing config block."
+msgstr ""
+
+#: src/Config/ConfigForm.php:346
+#, php-format
+msgid "Entry %d skipped: missing or invalid id."
+msgstr ""
+
+#: src/Config/ConfigForm.php:364
+#, php-format
+msgid "Entry %d (%s) could not be inserted into database."
+msgstr ""
+
+#: src/Config/ConfigForm.php:375
+#, php-format
+msgid "Config %s restored but claim mappings had validation errors."
+msgstr ""
+
+#: src/Config/ConfigForm.php:384
+#, php-format
+msgid "Restore successful: %d IDP configuration(s) restored."
+msgstr ""
+
+#: src/Config/ConfigForm.php:393
+msgid "Restore completed but no configurations were imported."
+msgstr ""
+
+#: src/Config/ConfigForm.php:411
+msgid "You do not have permission to perform this action."
+msgstr ""
+
+#: src/Config/ConfigForm.php:426
+msgid "User disabled and session forced logoff."
+msgstr ""
+
+#: src/Config/ConfigForm.php:428
+msgid "Login state session not found."
+msgstr ""
+
+#: src/Config/ConfigForm.php:517
+msgid "Successfully added new samlSSO configuration."
+msgstr "Configuración de samlSSO agregada exitosamente."
+
+#: src/Config/ConfigForm.php:521
+msgid "Unable to add new samlSSO configuration, please review error logging"
+msgstr ""
+"No se pudo agregar la nueva configuración de samlSSO; por favor, revisá el "
+"registro de errores"
+
+#: src/Config/ConfigForm.php:526 src/Config/ConfigForm.php:571
+msgid "Configuration invalid, please correct all ⭕ errors first"
+msgstr ""
+"Configuración inválida; por favor, corregí primero todos los errores ⭕"
+
+#: src/Config/ConfigForm.php:562 src/LoginFlow/LoginFlowForm.php:105
+msgid "Configuration updated successfully"
+msgstr "Configuración actualizada exitosamente"
+
+#: src/Config/ConfigForm.php:566 src/LoginFlow/LoginFlowForm.php:109
+msgid "Configuration update failed, check your update rights or error logging"
+msgstr ""
+"La actualización de la configuración falló; revisá tus permisos de "
+"actualización o el registro de errores"
+
+#: src/Config/ConfigForm.php:591
+msgid "Configuration deleted successfully"
+msgstr "Configuración eliminada exitosamente"
+
+#: src/Config/ConfigForm.php:595
+msgid "Not allowed or error deleting SAML configuration!"
+msgstr "¡No está permitido o hubo un error al eliminar la configuración SAML!"
+
+#: src/Config/ConfigForm.php:614 src/LoginFlow/LoginFlowForm.php:133
+msgid "Invalid request, redirecting back"
+msgstr "Solicitud inválida, redirigiendo de vuelta"
+
+#: src/Config/ConfigForm.php:740
+msgid "This claim key has not been observed in any SAML responses yet."
+msgstr ""
+
+#: src/Config/ConfigForm.php:792 src/LoginFlow/LoginFlowForm.php:184
+msgid "Email Address"
+msgstr "Dirección de Correo Electrónico"
+
+#: src/Config/ConfigForm.php:793 src/LoginFlow/LoginFlowForm.php:185
+msgid "Transient"
+msgstr "Transitorio"
+
+#: src/Config/ConfigForm.php:794 src/LoginFlow/LoginFlowForm.php:186
+msgid "Persistent"
+msgstr "Persistente"
+
+#: src/Config/ConfigForm.php:795 src/LoginFlow/LoginFlowForm.php:189
+msgid "PasswordProtectedTransport"
+msgstr "TransporteProtegidoConContraseña"
+
+#: src/Config/ConfigForm.php:797 src/LoginFlow/LoginFlowForm.php:191
+msgid "X509"
+msgstr "X509"
+
+#: src/Config/ConfigForm.php:798 src/LoginFlow/LoginFlowForm.php:192
+msgid "none"
+msgstr "ninguno"
+
+#: src/Config/ConfigForm.php:799 src/LoginFlow/LoginFlowForm.php:195
+msgid "Exact"
+msgstr "Exacto"
+
+#: src/Config/ConfigForm.php:802 src/LoginFlow/LoginFlowForm.php:198
+msgid "Better"
+msgstr "Mejor"
+
+#: src/Config/ConfigItem.php:101 src/LoginFlow/LoginFlowItem.php:97
 msgid "⭕ ID must be a positive numeric value!"
 msgstr "⭕ ¡La ID debe ser un valor numérico positivo!"
 
-#: src/Config/ConfigItem.php:98 src/LoginFlow/LoginFlowItem.php:93
+#: src/Config/ConfigItem.php:105 src/LoginFlow/LoginFlowItem.php:101
 msgid "Unique identifier for this configuration"
 msgstr "Identificador único para esta configuración"
 
-#: src/Config/ConfigItem.php:99 src/LoginFlow/LoginFlowItem.php:94
+#: src/Config/ConfigItem.php:106 src/LoginFlow/LoginFlowItem.php:102
 msgid "CONFIG ID"
 msgstr "ID DE CONFIGURACIÓN"
 
-#: src/Config/ConfigItem.php:112
+#: src/Config/ConfigItem.php:120
 msgid ""
-"This name is shown with the login button on the login page. Try to keep this"
-" name short en to the point."
+"This name is shown with the login button on the login page. Try to keep this "
+"name short en to the point."
 msgstr ""
-"Este nombre se muestra junto al botón de inicio de sesión. Tratá de mantener"
-" el nombre breve y conciso."
+"Este nombre se muestra junto al botón de inicio de sesión. Tratá de mantener "
+"el nombre breve y conciso."
 
-#: src/Config/ConfigItem.php:113
+#: src/Config/ConfigItem.php:121
 msgid "FRIENDLY NAME"
 msgstr "NOMBRE AMIGABLE"
 
-#: src/Config/ConfigItem.php:118
+#: src/Config/ConfigItem.php:126
 msgid "⭕ Name is a required field"
 msgstr "⭕ El nombre es un campo obligatorio"
 
-#: src/Config/ConfigItem.php:127
+#: src/Config/ConfigItem.php:137
 msgid "USERDOMAIN"
 msgstr "DOMINIO DE USUARIO"
 
-#: src/Config/ConfigItem.php:132
+#: src/Config/ConfigItem.php:142
 msgid "⭕ "
 msgstr "⭕ "
 
-#: src/Config/ConfigItem.php:147
+#: src/Config/ConfigItem.php:159
 msgid ""
 "⭕ Provided certificate does not like look a valid (base64 encoded) "
 "certificate"
 msgstr ""
-"⭕ El certificado provisto no parece ser un certificado válido (codificado en"
-" base64)"
+"⭕ El certificado provisto no parece ser un certificado válido (codificado "
+"en base64)"
 
-#: src/Config/ConfigItem.php:151
+#: src/Config/ConfigItem.php:164
 msgid ""
 "The base64 encoded x509 service provider certificate. Used to sign and "
 "encrypt messages send by the service provider to the identity provider. "
@@ -114,11 +416,11 @@ msgstr ""
 "proveedor de identidad. Es obligatorio para la mayoría de las opciones de "
 "seguridad"
 
-#: src/Config/ConfigItem.php:152
+#: src/Config/ConfigItem.php:165
 msgid "SP CERTIFICATE"
 msgstr "CERTIFICADO SP"
 
-#: src/Config/ConfigItem.php:167
+#: src/Config/ConfigItem.php:182
 msgid ""
 "The base64 encoded x509 service providers private key. Should match the "
 "modulus of the provided X509 service provider certificate"
@@ -127,11 +429,11 @@ msgstr ""
 "Debería coincidir con el módulo del certificado X509 del proveedor de "
 "servicio provisto"
 
-#: src/Config/ConfigItem.php:168
+#: src/Config/ConfigItem.php:183
 msgid "SP PRIVATE KEY"
 msgstr "CLAVE PRIVADA SP"
 
-#: src/Config/ConfigItem.php:179
+#: src/Config/ConfigItem.php:196
 msgid ""
 "The Service Provider nameid format specifies the constraints on the name "
 "identifier to be used to represent the requested subject."
@@ -140,39 +442,39 @@ msgstr ""
 "el identificador de nombre que se va a usar para representar al sujeto "
 "solicitado."
 
-#: src/Config/ConfigItem.php:180
+#: src/Config/ConfigItem.php:197
 msgid "NAMEID FORMAT"
 msgstr "FORMATO NAMEID"
 
-#: src/Config/ConfigItem.php:185
+#: src/Config/ConfigItem.php:202
 msgid "Service provider name id is a required field"
 msgstr "El name id del proveedor de servicio es un campo obligatorio"
 
-#: src/Config/ConfigItem.php:192
+#: src/Config/ConfigItem.php:211
 msgid ""
 "Identifier of the IdP entity which is an URL provided by the SAML2 Identity "
 "Provider (IdP)"
 msgstr ""
-"Identificador de la entidad IdP, que es una URL provista por el Proveedor de"
-" Identidad SAML2 (IdP)"
+"Identificador de la entidad IdP, que es una URL provista por el Proveedor de "
+"Identidad SAML2 (IdP)"
 
-#: src/Config/ConfigItem.php:193
+#: src/Config/ConfigItem.php:212
 msgid "ENTITY ID"
 msgstr "ID DE ENTIDAD"
 
-#: src/Config/ConfigItem.php:198
+#: src/Config/ConfigItem.php:217
 msgid "⭕ Identity provider entity id is a required field"
 msgstr "⭕ El ID de entidad del proveedor de identidad es un campo obligatorio"
 
-#: src/Config/ConfigItem.php:211
+#: src/Config/ConfigItem.php:231
 msgid "⭕ The IdP SSO URL is a required field!<br>"
 msgstr "⭕ ¡La URL SSO del IdP es un campo obligatorio!<br>"
 
-#: src/Config/ConfigItem.php:216
+#: src/Config/ConfigItem.php:236
 msgid "⭕ Invalid IdP SSO URL, use: scheme://host.domain.tld/path/"
 msgstr "⭕ URL SSO del IdP inválida, usá: scheme://host.domain.tld/path/"
 
-#: src/Config/ConfigItem.php:223
+#: src/Config/ConfigItem.php:244
 msgid ""
 "Single Sign On Service endpoint of the IdP. URL Target of the IdP where the "
 "Authentication Request Message will be sent. OneLogin PHPSAML only supports "
@@ -182,38 +484,38 @@ msgstr ""
 "del IdP a donde se enviará el Mensaje de Solicitud de Autenticación. "
 "OneLogin PHPSAML solo soporta el binding 'HTTP-redirect' para este endpoint."
 
-#: src/Config/ConfigItem.php:224
+#: src/Config/ConfigItem.php:245
 msgid "SSO URL"
 msgstr "URL SSO"
 
-#: src/Config/ConfigItem.php:246
+#: src/Config/ConfigItem.php:268
 msgid "⭕ Invalid Idp SLO URL, use: scheme://host.domain.tld/path/"
 msgstr "⭕ URL SLO del IdP inválida, usá: scheme://host.domain.tld/path/"
 
-#: src/Config/ConfigItem.php:249
+#: src/Config/ConfigItem.php:272
 msgid ""
-"Single Logout service endpoint of the IdP. URL Location of the IdP where SLO"
-" Request will be sent.OneLogin PHPSAML only supports the 'HTTP-redirect' "
+"Single Logout service endpoint of the IdP. URL Location of the IdP where SLO "
+"Request will be sent.OneLogin PHPSAML only supports the 'HTTP-redirect' "
 "binding for this endpoint."
 msgstr ""
 "Endpoint del servicio de Cierre de Sesión Único del IdP. Es la URL de "
 "ubicación del IdP a donde se enviará la Solicitud SLO.OneLogin PHPSAML solo "
 "soporta el binding 'HTTP-redirect' para este endpoint."
 
-#: src/Config/ConfigItem.php:250
+#: src/Config/ConfigItem.php:273
 msgid "SLO URL"
 msgstr "URL SLO"
 
-#: src/Config/ConfigItem.php:269
+#: src/Config/ConfigItem.php:294
 msgid "⭕ Valid Idp X509 certificate is required! (base64 encoded)"
 msgstr ""
 "⭕ ¡Se requiere un certificado X509 del Idp válido! (codificado en base64)"
 
-#: src/Config/ConfigItem.php:273
+#: src/Config/ConfigItem.php:299
 msgid ""
 "The Public Base64 encoded x509 certificate used by the IdP. Fingerprinting "
-"can be used, but is not recommended. Fingerprinting requires you to manually"
-" alter the Saml Config array located in ConfigEntity.php and provide the "
+"can be used, but is not recommended. Fingerprinting requires you to manually "
+"alter the Saml Config array located in ConfigEntity.php and provide the "
 "required configuration options"
 msgstr ""
 "El certificado x509 Público codificado en Base64 que usa el IdP. Podés usar "
@@ -221,133 +523,139 @@ msgstr ""
 "alteres manualmente el array de Configuración Saml ubicado en "
 "ConfigEntity.php y que proveas las opciones de configuración requeridas"
 
-#: src/Config/ConfigItem.php:274
+#: src/Config/ConfigItem.php:300
 msgid "X509 CERTIFICATE"
 msgstr "CERTIFICADO X509"
 
-#: src/Config/ConfigItem.php:299
+#: src/Config/ConfigItem.php:327
 msgid ""
 "Authentication context needs to be satisfied by the IdP in order to allow "
 "Saml login. Set to \"none\" and OneLogin PHPSAML will not send an "
 "AuthContext in the AuthNRequest. Or, select one or more options using the "
 "\"control+click\" combination."
 msgstr ""
-"La autenticación de contexto debe ser satisfecha por el IdP para permitir el"
-" inicio de sesión con Saml. Establecé en \"ninguno\" y OneLogin PHPSAML no "
-"va a enviar un AuthContext en el AuthNRequest. O, seleccioná una o más "
-"opciones usando la combinación de \"control+clic\"."
+"La autenticación de contexto debe ser satisfecha por el IdP para permitir el "
+"inicio de sesión con Saml. Establecé en \"ninguno\" y OneLogin PHPSAML no va "
+"a enviar un AuthContext en el AuthNRequest. O, seleccioná una o más opciones "
+"usando la combinación de \"control+clic\"."
 
-#: src/Config/ConfigItem.php:300
+#: src/Config/ConfigItem.php:328
 msgid "REQ AUTHN CONTEXT"
 msgstr "CONTEXTO AUTHN REQUERIDO"
 
-#: src/Config/ConfigItem.php:305
+#: src/Config/ConfigItem.php:333
 msgid "⭕ Requested authN context is a required field"
 msgstr "⭕ El contexto authN solicitado es un campo obligatorio"
 
-#: src/Config/ConfigItem.php:310
+#: src/Config/ConfigItem.php:340
 msgid "AUTHN Comparison attribute value"
 msgstr "Valor del atributo de Comparación AUTHN"
 
-#: src/Config/ConfigItem.php:311
+#: src/Config/ConfigItem.php:341
 msgid "AUTHN COMPARISON"
 msgstr "COMPARACIÓN DE AUTHN"
 
-#: src/Config/ConfigItem.php:316
+#: src/Config/ConfigItem.php:346
 msgid "⭕ Requested authN context comparison is a required field"
 msgstr ""
 "⭕ La comparación del contexto authN solicitado es un campo obligatorio"
 
-#: src/Config/ConfigItem.php:321
-msgid ""
-"The FontAwesome (https://fontawesome.com/) icon to show on the button on the"
-" login page."
+#: src/Config/ConfigItem.php:353
+#, fuzzy, php-format
+msgid "The FontAwesome (%s) icon to show on the button on the login page."
 msgstr ""
 "El ícono de FontAwesome (https://fontawesome.com/) para mostrar en el botón "
 "de la página de inicio de sesión."
 
-#: src/Config/ConfigItem.php:322
+#: src/Config/ConfigItem.php:354
 msgid "LOGIN ICON"
 msgstr "ÍCONO DE INICIO DE SESIÓN"
 
-#: src/Config/ConfigItem.php:327
+#: src/Config/ConfigItem.php:359
 msgid "⭕ Configuration icon is a required field"
 msgstr "⭕ El ícono de configuración es un campo obligatorio"
 
-#: src/Config/ConfigItem.php:332
+#: src/Config/ConfigItem.php:366
 msgid "The comments"
 msgstr "Los comentarios"
 
-#: src/Config/ConfigItem.php:333
+#: src/Config/ConfigItem.php:367
 msgid "COMMENTS"
 msgstr "COMENTARIOS"
 
-#: src/Config/ConfigItem.php:344
+#: src/Config/ConfigItem.php:379
+msgid "The anonymized SAML response XML structure"
+msgstr ""
+
+#: src/Config/ConfigItem.php:380
+msgid "SAML Response XML Structure"
+msgstr ""
+
+#: src/Config/ConfigItem.php:393
 msgid "The date this configuration item was created"
 msgstr "La fecha en que se creó este elemento de configuración"
 
-#: src/Config/ConfigItem.php:345
+#: src/Config/ConfigItem.php:394
 msgid "CREATE DATE"
 msgstr "FECHA DE CREACIÓN"
 
-#: src/Config/ConfigItem.php:357
+#: src/Config/ConfigItem.php:408
 msgid "The date this config was modified"
 msgstr "La fecha en que se modificó esta configuración"
 
-#: src/Config/ConfigItem.php:358
+#: src/Config/ConfigItem.php:409
 msgid "MODIFICATION DATE"
 msgstr "FECHA DE MODIFICACIÓN"
 
-#: src/Config/ConfigItem.php:373
+#: src/Config/ConfigItem.php:429
 msgid "Is this configuration marked as deleted by GLPI"
 msgstr "Está marcada esta configuración como eliminada por GLPI"
 
-#: src/Config/ConfigItem.php:374
+#: src/Config/ConfigItem.php:430
 msgid "IS DELETED"
 msgstr "ESTÁ ELIMINADA"
 
-#: src/Config/ConfigItem.php:382
+#: src/Config/ConfigItem.php:442
 msgid ""
-"Indicates if this configuration activated. Disabled configurations cannot be"
-" used to login into GLPI and will NOT be shown on the login page."
+"Indicates if this configuration activated. Disabled configurations cannot be "
+"used to login into GLPI and will NOT be shown on the login page."
 msgstr ""
-"Indica si esta configuración está activada. Las configuraciones desactivadas"
-" no se pueden usar para iniciar sesión en GLPI y NO se van a mostrar en la "
+"Indica si esta configuración está activada. Las configuraciones desactivadas "
+"no se pueden usar para iniciar sesión en GLPI y NO se van a mostrar en la "
 "página de inicio de sesión."
 
-#: src/Config/ConfigItem.php:383
+#: src/Config/ConfigItem.php:443
 msgid "IS ACTIVE"
 msgstr "ESTÁ ACTIVA"
 
-#: src/Config/ConfigItem.php:391
+#: src/Config/ConfigItem.php:455
 msgid ""
-"If enabled PHPSAML will replace the default GLPI login screen with a version"
-" that does not have the default GLPI login options and only allows the user "
+"If enabled PHPSAML will replace the default GLPI login screen with a version "
+"that does not have the default GLPI login options and only allows the user "
 "to authenticate using the configured SAML2 idps. This setting can be "
 "bypassed using a bypass URI parameter"
 msgstr ""
 "Si está activado, PHPSAML va a reemplazar la pantalla de inicio de sesión "
 "por defecto de GLPI por una versión que no tiene las opciones de inicio de "
 "sesión por defecto de GLPI y solo le permite al usuario autenticarse usando "
-"los idps de SAML2 configurados. Esta configuración se puede omitir usando un"
-" parámetro de URI de omisión"
+"los idps de SAML2 configurados. Esta configuración se puede omitir usando un "
+"parámetro de URI de omisión"
 
-#: src/Config/ConfigItem.php:392
+#: src/Config/ConfigItem.php:456
 msgid "ENFORCED"
 msgstr "FORZADO"
 
-#: src/Config/ConfigItem.php:400
-msgid ""
-"Is GLPI positioned behind a proxy that alters the SAML response scheme?"
+#: src/Config/ConfigItem.php:468
+msgid "Is GLPI positioned behind a proxy that alters the SAML response scheme?"
 msgstr ""
 "¿Está GLPI ubicado detrás de un proxy que altera el esquema de respuestas "
 "SAML?"
 
-#: src/Config/ConfigItem.php:401
+#: src/Config/ConfigItem.php:469
 msgid "REQUESTS PROXIED"
 msgstr "SOLICITUDES PROXIED"
 
-#: src/Config/ConfigItem.php:409
+#: src/Config/ConfigItem.php:481
 msgid ""
 "If enabled the OneLogin PHPSAML Toolkit will reject unsigned or unencrypted "
 "messages if it expects them to be signed or encrypted. Also it will reject "
@@ -358,14 +666,14 @@ msgstr ""
 "Si está activado, el Toolkit PHPSAML de OneLogin va a rechazar los mensajes "
 "sin firmar o sin cifrar si espera que estén firmados o cifrados. También va "
 "a rechazar los mensajes si el estándar SAML no es estrictamente seguido: la "
-"validación se aplica también a Destino, NameId y Condiciones. Es fuertemente"
-" aconsejable en entorno de producción."
+"validación se aplica también a Destino, NameId y Condiciones. Es fuertemente "
+"aconsejable en entorno de producción."
 
-#: src/Config/ConfigItem.php:410
+#: src/Config/ConfigItem.php:482
 msgid "STRICT"
 msgstr "ESTRICTO"
 
-#: src/Config/ConfigItem.php:418
+#: src/Config/ConfigItem.php:494
 msgid ""
 "If enabled it will enforce OneLogin PHPSAML to print status and error "
 "messages. Be aware that not all message's might be captured by samlSSO and "
@@ -375,24 +683,85 @@ msgstr ""
 "estado y error. Tené en cuenta que es posible que samlSSO no capture todos "
 "los mensajes y, por lo tanto, puede que no sean visibles."
 
-#: src/Config/ConfigItem.php:427
+#: src/Config/ConfigItem.php:507
 msgid ""
 "If enabled samlSSO will create new GLPI users on the fly and assign the "
 "properties defined in the samlSSO assignment rules. If disables users that "
 "do not have a valid GLPI user will not be able to login into GLPI until a "
 "user is manually created."
 msgstr ""
-"Si está activado, samlSSO va a crear nuevos usuarios de GLPI sobre la marcha"
-" y les va a asignar las propiedades definidas en las reglas de asignación de"
-" samlSSO. Si está desactivado, los usuarios que no tienen un usuario de GLPI"
-" válido no van a poder iniciar sesión en GLPI hasta que un usuario sea "
-"creado manualmente."
+"Si está activado, samlSSO va a crear nuevos usuarios de GLPI sobre la marcha "
+"y les va a asignar las propiedades definidas en las reglas de asignación de "
+"samlSSO. Si está desactivado, los usuarios que no tienen un usuario de GLPI "
+"válido no van a poder iniciar sesión en GLPI hasta que un usuario sea creado "
+"manualmente."
 
-#: src/Config/ConfigItem.php:428
+#: src/Config/ConfigItem.php:508
 msgid "JIT USER CREATION"
 msgstr "CREACIÓN DE USUARIOS JIT"
 
-#: src/Config/ConfigItem.php:436
+#: src/Config/ConfigItem.php:526
+msgid ""
+"If enabled, user fields mapped from SAML claims and assignment rules will be "
+"synchronized on every successful login."
+msgstr ""
+
+#: src/Config/ConfigItem.php:527
+msgid "SYNC ON LOGIN"
+msgstr ""
+
+#: src/Config/ConfigItem.php:545
+msgid ""
+"If enabled, GLPI will require all SAML protocol messages received from the "
+"Identity Provider (IdP) to be cryptographically signed."
+msgstr ""
+
+#: src/Config/ConfigItem.php:546
+msgid "REQUIRE SIGNED MESSAGES"
+msgstr ""
+
+#: src/Config/ConfigItem.php:564
+msgid ""
+"If enabled, GLPI will require individual SAML assertions within the SAML "
+"message to be signed. If unsigned, assertions will be rejected."
+msgstr ""
+
+#: src/Config/ConfigItem.php:565
+msgid "REQUIRE SIGNED ASSERTIONS"
+msgstr ""
+
+#: src/Config/ConfigItem.php:583
+msgid ""
+"If enabled, GLPI will expect the SAML assertions containing user claims to "
+"be encrypted. GLPI will decrypt them using the SP private key."
+msgstr ""
+
+#: src/Config/ConfigItem.php:584
+msgid "REQUIRE ENCRYPTED ASSERTIONS"
+msgstr ""
+
+#: src/Config/ConfigItem.php:602
+msgid ""
+"If enabled, the SAML SP metadata XML generated by GLPI will be "
+"cryptographically signed using the Service Provider certificate."
+msgstr ""
+
+#: src/Config/ConfigItem.php:603
+msgid "SIGN SP METADATA"
+msgstr ""
+
+#: src/Config/ConfigItem.php:621
+msgid ""
+"If enabled, GLPI will strictly require a NameID element to be present in the "
+"SAML assertion payload."
+msgstr ""
+
+#: src/Config/ConfigItem.php:622
+#, fuzzy
+msgid "REQUIRE NAMEID"
+msgstr "CIFRAR NAMEID"
+
+#: src/Config/ConfigItem.php:634
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will encrypt the "
 "<samlp:logoutRequest> sent by this SP using the provided SP certificate and "
@@ -405,83 +774,87 @@ msgstr ""
 "automáticamente si no se proporciona, o no es válido, ningún certificado y "
 "clave SP."
 
-#: src/Config/ConfigItem.php:437
+#: src/Config/ConfigItem.php:635
 msgid "ENCRYPT NAMEID"
 msgstr "CIFRAR NAMEID"
 
-#: src/Config/ConfigItem.php:445
+#: src/Config/ConfigItem.php:647
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will sign the <samlp:AuthnRequest> "
 "messages send by this SP. The IDP should consult the metadata to get the "
 "information required to validate the signatures."
 msgstr ""
-"Si está activado, el toolkit PHPSAML de OneLogin va a firmar los mensajes de"
-" <samlp:AuthnRequest> enviados por este SP. El IDP debe consultar los "
+"Si está activado, el toolkit PHPSAML de OneLogin va a firmar los mensajes de "
+"<samlp:AuthnRequest> enviados por este SP. El IDP debe consultar los "
 "metadatos para obtener la información requerida para validar las firmas."
 
-#: src/Config/ConfigItem.php:446
+#: src/Config/ConfigItem.php:648
 msgid "SIGN AUTHN REQUEST"
 msgstr "FIRMAR SOLICITUD AUTHN"
 
-#: src/Config/ConfigItem.php:454
+#: src/Config/ConfigItem.php:660
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutRequest> "
 "messages send by this SP."
 msgstr ""
-"Si está activado, el toolkit PHPSAML de OneLogin va a firmar los mensajes de"
-" <samlp:logoutRequest> enviados por este SP."
+"Si está activado, el toolkit PHPSAML de OneLogin va a firmar los mensajes de "
+"<samlp:logoutRequest> enviados por este SP."
 
-#: src/Config/ConfigItem.php:455
+#: src/Config/ConfigItem.php:661
 msgid "SIGN LOGOUT REQUEST"
 msgstr "FIRMAR SOLICITUD DE CIERRE DE SESIÓN"
 
-#: src/Config/ConfigItem.php:463
+#: src/Config/ConfigItem.php:673
 msgid ""
-"If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutResponse>"
-" messages send by this SP."
+"If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutResponse> "
+"messages send by this SP."
 msgstr ""
-"Si está activado, el toolkit PHPSAML de OneLogin va a firmar los mensajes de"
-" <samlp:logoutResponse> enviados por este SP."
+"Si está activado, el toolkit PHPSAML de OneLogin va a firmar los mensajes de "
+"<samlp:logoutResponse> enviados por este SP."
 
-#: src/Config/ConfigItem.php:464
+#: src/Config/ConfigItem.php:674
 msgid "SIGN LOGOUT RESPONSE"
 msgstr "FIRMAR RESPUESTA DE CIERRE DE SESIÓN"
 
-#: src/Config/ConfigItem.php:472
+#: src/Config/ConfigItem.php:686
 msgid ""
-"If enabled the authentication requests send to the IdP will be compressed by"
-" the SP."
+"If enabled the authentication requests send to the IdP will be compressed by "
+"the SP."
 msgstr ""
-"Si está activado, las solicitudes de autenticación enviadas al IdP van a ser"
-" comprimidas por el SP."
+"Si está activado, las solicitudes de autenticación enviadas al IdP van a ser "
+"comprimidas por el SP."
 
-#: src/Config/ConfigItem.php:473
+#: src/Config/ConfigItem.php:687
 msgid "COMPRESS REQUESTS"
 msgstr "COMPRIMIR SOLICITUDES"
 
-#: src/Config/ConfigItem.php:481
+#: src/Config/ConfigItem.php:699
 msgid "If enabled the SP expects responses send by the IdP to be compressed."
 msgstr ""
 "Si está activado, el SP espera que las respuestas enviadas por el IdP estén "
 "comprimidas."
 
-#: src/Config/ConfigItem.php:482
+#: src/Config/ConfigItem.php:700
 msgid "COMPRESS RESPONSES"
 msgstr "COMPRIMIR RESPUESTAS"
 
-#: src/Config/ConfigItem.php:490
+#: src/Config/ConfigItem.php:712
 msgid ""
-"If enabled the SP will validate all received XMLs. In order to validate the XML\n"
-"                                                        \"strict\" security setting must be true."
+"If enabled the SP will validate all received XMLs. In order to validate the "
+"XML\n"
+"                                                        \"strict\" security "
+"setting must be true."
 msgstr ""
-"Si está activado, el SP va a validar todos los XML recibidos. Para validar el XML\n"
-"                                                        la configuración de seguridad \"estricto\" debe ser verdadera."
+"Si está activado, el SP va a validar todos los XML recibidos. Para validar "
+"el XML\n"
+"                                                        la configuración de "
+"seguridad \"estricto\" debe ser verdadera."
 
-#: src/Config/ConfigItem.php:492
+#: src/Config/ConfigItem.php:714
 msgid "VALIDATE XML"
 msgstr "VALIDAR XML"
 
-#: src/Config/ConfigItem.php:500
+#: src/Config/ConfigItem.php:726
 msgid ""
 "If enabled, SAMLResponses with an empty value at its Destination attribute "
 "will not be rejected for this fact."
@@ -489,25 +862,25 @@ msgstr ""
 "Si está activado, las Respuestas SAML con un valor vacío en su atributo de "
 "Destino no van a ser rechazadas por este hecho."
 
-#: src/Config/ConfigItem.php:501
+#: src/Config/ConfigItem.php:727
 msgid "RELAX DEST VALIDATION"
 msgstr "FLEXIBILIZAR VALIDACIÓN DE DESTINO"
 
-#: src/Config/ConfigItem.php:509
+#: src/Config/ConfigItem.php:739
 msgid ""
-"ADFS URL-Encodes SAML data as lowercase, and the OneLogin PHPSAML toolkit by"
-" default uses uppercase. Enable this setting for ADFS compatibility on "
+"ADFS URL-Encodes SAML data as lowercase, and the OneLogin PHPSAML toolkit by "
+"default uses uppercase. Enable this setting for ADFS compatibility on "
 "signature verification"
 msgstr ""
-"ADFS Codifica los datos SAML en URL como minúsculas, y el toolkit PHPSAML de"
-" OneLogin usa mayúsculas por defecto. Activá esta configuración para la "
+"ADFS Codifica los datos SAML en URL como minúsculas, y el toolkit PHPSAML de "
+"OneLogin usa mayúsculas por defecto. Activá esta configuración para la "
 "compatibilidad con ADFS en la verificación de firmas"
 
-#: src/Config/ConfigItem.php:510
+#: src/Config/ConfigItem.php:740
 msgid "LOWER CASE ENCODING"
 msgstr "CODIFICACIÓN EN MINÚSCULAS"
 
-#: src/Config/ConfigItem.php:564
+#: src/Config/ConfigItem.php:800
 msgid ""
 "⚠️ Warning, do not use the 'withlove.from.donuts.nl' example certificates. "
 "They offer no additional protection."
@@ -515,351 +888,253 @@ msgstr ""
 "⚠️ Advertencia, no uses los certificados de ejemplo "
 "'withlove.from.donuts.nl'. No ofrecen ninguna protección adicional."
 
-#: src/Config/ConfigItem.php:572
+#: src/Config/ConfigItem.php:810
 msgid ""
-"⭕ Certificate must be wrapped in valid BEGIN CERTIFICATE and END CERTIFICATE"
-" tags"
+"⭕ Certificate must be wrapped in valid BEGIN CERTIFICATE and END "
+"CERTIFICATE tags"
 msgstr ""
 "⭕ El certificado debe estar envuelto en etiquetas válidas de BEGIN "
 "CERTIFICATE y END CERTIFICATE"
 
-#: src/Config/ConfigItem.php:576
+#: src/Config/ConfigItem.php:816
 msgid "⭕ Certificate should not contain \"carriage returns\" [<CR>]"
 msgstr "⭕ El certificado no debe contener \"retornos de carro\" [<CR>]"
 
-#: src/Config/ConfigItem.php:580
+#: src/Config/ConfigItem.php:820
 msgid "⭕ No valid X509 certificate found"
 msgstr "⭕ No se encontró ningún certificado X509 válido"
 
-#: src/Config/ConfigItem.php:583
+#: src/Config/ConfigItem.php:823
 msgid "⚠️ OpenSSL is not available, GLPI cant validate your certificate"
 msgstr "⚠️ OpenSSL no está disponible; GLPI no puede validar tu certificado"
 
-#: src/Config/ConfigForm.php:159
-msgid "Successfully added new samlSSO configuration."
-msgstr "Configuración de samlSSO agregada exitosamente."
-
-#: src/Config/ConfigForm.php:163
-msgid "Unable to add new samlSSO configuration, please review error logging"
-msgstr ""
-"No se pudo agregar la nueva configuración de samlSSO; por favor, revisá el "
-"registro de errores"
-
-#: src/Config/ConfigForm.php:168
-msgid "Configuration invalid, please correct all ⭕ errors first"
-msgstr ""
-"Configuración inválida; por favor, corregí primero todos los errores ⭕"
-
-#: src/Config/ConfigForm.php:196 src/LoginFlow/LoginFlowForm.php:100
-msgid "Configuration updated successfully"
-msgstr "Configuración actualizada exitosamente"
-
-#: src/Config/ConfigForm.php:200 src/LoginFlow/LoginFlowForm.php:104
-msgid "Configuration update failed, check your update rights or error logging"
-msgstr ""
-"La actualización de la configuración falló; revisá tus permisos de "
-"actualización o el registro de errores"
-
-#: src/Config/ConfigForm.php:205 src/LoginFlow/LoginFlowForm.php:109
-msgid "Configuration invalid please correct all ⭕ errors first"
-msgstr ""
-"Configuración inválida; por favor, corregí primero todos los errores ⭕"
-
-#: src/Config/ConfigForm.php:225
-msgid "Configuration deleted successfully"
-msgstr "Configuración eliminada exitosamente"
-
-#: src/Config/ConfigForm.php:229
-msgid "Not allowed or error deleting SAML configuration!"
-msgstr "¡No está permitido o hubo un error al eliminar la configuración SAML!"
-
-#: src/Config/ConfigForm.php:248 src/LoginFlow/LoginFlowForm.php:128
-msgid "Invalid request, redirecting back"
-msgstr "Solicitud inválida, redirigiendo de vuelta"
-
-#: src/Config/ConfigForm.php:357 src/LoginFlow/LoginFlowForm.php:176
-msgid "Email Address"
-msgstr "Dirección de Correo Electrónico"
-
-#: src/Config/ConfigForm.php:358 src/LoginFlow/LoginFlowForm.php:177
-msgid "Transient"
-msgstr "Transitorio"
-
-#: src/Config/ConfigForm.php:359 src/LoginFlow/LoginFlowForm.php:178
-msgid "Persistent"
-msgstr "Persistente"
-
-#: src/Config/ConfigForm.php:360 src/LoginFlow/LoginFlowForm.php:179
-msgid "PasswordProtectedTransport"
-msgstr "TransporteProtegidoConContraseña"
-
-#: src/Config/ConfigForm.php:362 src/LoginFlow/LoginFlowForm.php:181
-msgid "X509"
-msgstr "X509"
-
-#: src/Config/ConfigForm.php:363 src/LoginFlow/LoginFlowForm.php:182
-msgid "none"
-msgstr "ninguno"
-
-#: src/Config/ConfigForm.php:364 src/LoginFlow/LoginFlowForm.php:183
-msgid "Exact"
-msgstr "Exacto"
-
-#: src/Config/ConfigForm.php:367 src/LoginFlow/LoginFlowForm.php:186
-msgid "Better"
-msgstr "Mejor"
-
-#: src/Config/ConfigEntity.php:344
-msgid ""
-"⚠️ SP private key does not seem to match provided SP certificates modulus."
-msgstr ""
-"⚠️ La clave privada del SP no parece coincidir con el módulo de los "
-"certificados SP proporcionados."
-
-#: src/Config/ConfigEntity.php:349
-msgid ""
-"⚠️ Will be defaulted to \"No\" because the provided SP certificate does not "
-"look valid!"
-msgstr ""
-"⚠️ ¡Se va a establecer \"No\" por defecto porque el certificado SP "
-"proporcionado no parece válido!"
-
-#: src/LoginFlow.php:162
-msgid "samlFlow"
-msgstr "samlFlow"
-
-#: src/LoginFlow.php:406
-msgid ""
-"Could not update the loginState and therefor stopped the loginFlow for:"
-msgstr ""
-"No se pudo actualizar el loginState y, por lo tanto, se detuvo el loginFlow "
-"para:"
-
-#: src/LoginFlow.php:495
-msgid "⚠️ Are you sure?"
-msgstr "⚠️ ¿Estás seguro/a?"
-
-#: src/LoginFlow.php:497
-msgid "Continue GLPI logout"
-msgstr "Continuar con el cierre de sesión de GLPI"
-
-#: src/LoginFlow.php:499
-msgid "Log out everywhere"
-msgstr "Cerrar sesión en todos lados"
-
-#: src/LoginFlow.php:549
-msgid "Login with external provider"
-msgstr "Iniciar sesión con proveedor externo"
-
-#: src/LoginFlow.php:584
-msgid "⚠️ Sorry we are unable to log you in"
-msgstr "⚠️ Lo sentimos, no te podemos iniciar sesión"
-
-#: src/LoginFlow.php:589 src/LoginFlow.php:629
-msgid "Return to GLPI"
-msgstr "Volver a GLPI"
-
-#: src/LoginFlow.php:625
-msgid "⚠️ An error occurred"
-msgstr "⚠️ Ocurrió un error"
-
-#: src/Config.php:123
+#: src/Config.php:125
 msgid "samlSSO"
 msgstr "samlSSO"
 
-#: src/Config.php:146 src/Exclude.php:86
+#: src/Config.php:149 src/Exclude.php:87
 msgid "Excluded paths"
 msgstr "Rutas excluídas"
 
-#: src/Config.php:181
+#: src/Config.php:184
 msgid "Idp entity ID"
 msgstr "ID de entidad Idp"
 
-#: src/LoginFlow/Acs.php:133
-msgid "Unable to fetch idp configuration with id:"
-msgstr "No se pudo obtener la configuración del idp con id:"
+#: src/CronTask.php:66
+msgid "Clean old SAML sessions"
+msgstr "Limpiar sesiones SAML antiguas"
 
-#: src/LoginFlow/Acs.php:134
-msgid "Assert saml"
-msgstr "Aserción saml"
+#: src/CronTask.php:67
+msgid "SAML sessions retention period (in days, 0 for infinite)"
+msgstr "Período de retención de sesiones SAML (en días, 0 para infinito)"
 
-#: src/LoginFlow/Acs.php:151 src/LoginFlow/Acs.php:165
-msgid "phpSaml::Settings->init"
-msgstr "phpSaml::Settings->init"
+#: src/CronTask.php:69
+msgid "Update GeoIP offline database"
+msgstr ""
 
-#: src/LoginFlow/Acs.php:178
-msgid "Could not process samlResponse with Error:"
-msgstr "No se pudo procesar la samlResponse con el Error:"
+#: src/LoginFlow/User.php:170 src/LoginFlow/User.php:175
+msgid "User with GlpiUserid: "
+msgstr "Usuario con GlpiUserid: "
 
-#: src/LoginFlow/Acs.php:179
-msgid "Saml::Response->init"
-msgstr "Saml::Response->init"
-
-#: src/LoginFlow/Acs.php:193
-msgid "LoginState"
-msgstr "Estado de Inicio de sesión"
-
-#: src/LoginFlow/Acs.php:202
+#: src/LoginFlow/User.php:187
 msgid ""
-"The received idp response did not contain the required samlResponse POST "
-"body or idpId to authenticate the user, see: "
-"https://codeberg.org/QuinQuies/glpisaml/wiki/ACS.php for more information"
+"Your SSO login was successful but no GLPI profile was assigned to your "
+"account. Please contact your GLPI administrator to assign a profile to your "
+"account."
 msgstr ""
-"La respuesta recibida del idp no contenía el cuerpo POST samlResponse o el "
-"idpId requeridos para autenticar al usuario. Consultá "
-"https://codeberg.org/QuinQuies/glpisaml/wiki/ACS.php para más información"
 
-#: src/LoginFlow/Acs.php:203
-msgid "Acs assertion"
-msgstr "Aserción Acs"
-
-#: src/LoginFlow/Acs.php:226
+#: src/LoginFlow/User.php:212
 msgid ""
-"It looks like this samlResponse has already been used to authenticate a different user.\n"
-"                                 Maybe an error occurred and you pressed F5 and accidently resend the samlResponse that is\n"
-"                                 already registered as processed. For security reasons we can not allow processed samlResponses\n"
-"                                 to be processed again. Please login again to generate a new samlResponse. Sorry for any inconvenience.\n"
-"                                 If the problem presists, then please contact your administrator.\n"
-"                                 See: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php for more information"
+"Your SSO login was successful but the identity provider configuration is "
+"invalid or disabled."
 msgstr ""
-"Parece que esta samlResponse ya fue usada para autenticar a un usuario diferente.\n"
-"                                 Quizás ocurrió un error y apretaste F5, reenviando accidentalmente la samlResponse que ya\n"
-"                                 está registrada como procesada. Por razones de seguridad, no podemos permitir que las samlResponses procesadas\n"
-"                                 se procesen de nuevo. Por favor, iniciá sesión otra vez para generar una nueva samlResponse. Disculpá las molestias.\n"
-"                                 Si el problema persiste, por favor, contactá a tu administrador.\n"
-"                                 Consultá: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php para más información"
 
-#: src/LoginFlow/Acs.php:246
+#: src/LoginFlow/User.php:221
 msgid ""
-"An error occured while trying to update the samlResponseId into the "
-"LoginState database. Review the saml log for more details"
+"Your SSO login was successful but there is no matching GLPI user account "
+"and\n"
+"                                                we failed to create one "
+"dynamically using Just In Time user creation. Please\n"
+"                                                request a GLPI administrator "
+"to review the logs and correct the problem or\n"
+"                                                request the administrator to "
+"create a GLPI user manually."
 msgstr ""
-"Ocurrió un error al intentar actualizar el samlResponseId en la base de "
-"datos de LoginState. Revisá el registro saml para más detalles"
+"Tu inicio de sesión SSO fue exitoso, pero no hay una cuenta de usuario de "
+"GLPI coincidente y\n"
+"                                                fallamos al crear una "
+"dinámicamente usando la creación de usuarios Just In Time. Por favor,\n"
+"                                                solicitá a un administrador "
+"de GLPI que revise los registros y corrija el problema, o\n"
+"                                                pedile al administrador que "
+"cree un usuario de GLPI manualmente."
 
-#: src/LoginFlow/Acs.php:257
+#: src/LoginFlow/User.php:234
+#, fuzzy
 msgid ""
-"GLPI did not expect an assertion from this Idp. The most likely reason is a race condition\n"
-"                                  causing an inconsistant loginState in the database or software bug. Please login again via the\n"
-"                                  GLPI-interface. Sorry for the inconvenience. See: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php\n"
-"                                  for more information"
+"Your SSO login was successful but no GLPI profile was assigned to your "
+"account and\n"
+"                                                    we failed to assign one "
+"dynamically using Just In Time user creation. Please\n"
+"                                                    request a GLPI "
+"administrator to review the logs and correct the problem or\n"
+"                                                    request the "
+"administrator to assign a GLPI profile manually."
 msgstr ""
-"GLPI no esperaba una aserción de este Idp. La razón más probable es una condición de carrera\n"
-"                                  que causa un loginState inconsistente en la base de datos o un bug de software. Por favor, iniciá sesión de nuevo a través de\n"
-"                                  la interfaz de GLPI. Disculpá las molestias. Consultá: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php\n"
-"                                  para más información"
+"Tu inicio de sesión SSO fue exitoso, pero no hay una cuenta de usuario de "
+"GLPI coincidente y\n"
+"                                                fallamos al crear una "
+"dinámicamente usando la creación de usuarios Just In Time. Por favor,\n"
+"                                                solicitá a un administrador "
+"de GLPI que revise los registros y corrija el problema, o\n"
+"                                                pedile al administrador que "
+"cree un usuario de GLPI manualmente."
 
-#: src/LoginFlow/Acs.php:261
-msgid "samlResponse assertion"
-msgstr "aserción de samlResponse"
-
-#: src/LoginFlow/Acs.php:274
+#: src/LoginFlow/User.php:242
 msgid ""
-"An error occured while trying to update the login phase to LoginState::PHASE_SAML_AUTH  into the LoginState database.\n"
-"                                  Review the saml log for more details"
+"Critical error: samlSSO was unable to fetch newly created user from the "
+"database!"
 msgstr ""
-"Ocurrió un error al intentar actualizar la fase de inicio de sesión a LoginState::PHASE_SAML_AUTH en la base de datos de LoginState.\n"
-"                                  Revisá el registro saml para más detalles"
+"Error crítico: ¡samlSSO no pudo obtener el usuario recién creado de la base "
+"de datos!"
 
-#: src/LoginFlow/Acs.php:282
+#: src/LoginFlow/User.php:264
+msgid "JIT was called with params:"
+msgstr "Se llamó a JIT con los parámetros:"
+
+#: src/LoginFlow/User.php:333
+msgid "Created by phpSaml Just-In-Time user creation on:"
+msgstr "Creado por la creación de usuarios Just-In-Time de phpSaml el:"
+
+#: src/LoginFlow/User.php:486
+msgid "JIT group already assigned:"
+msgstr ""
+
+#: src/LoginFlow/User.php:497
+msgid "JIT failed to assign groupID:"
+msgstr "JIT falló al asignar el ID de grupo:"
+
+#: src/LoginFlow/User.php:502
+msgid "JIT assigned groupID:"
+msgstr "JIT asignó el ID de grupo:"
+
+#: src/LoginFlow/User.php:509
+msgid "JIT found no groupId to add.\n"
+msgstr "JIT no encontró ningún Id de grupo para agregar.\n"
+
+#: src/LoginFlow/User.php:533
+msgid "JIT found entity for profile assignment:"
+msgstr "JIT encontró la entidad para la asignación de perfiles:"
+
+#: src/LoginFlow/User.php:535
 msgid ""
-"Validation of the samlResponse document failed. Review the saml log for more"
-" details"
+"JIT didnt find a profile for entity assignment. Profile asignment might not "
+"work.\n"
 msgstr ""
-"La validación del documento samlResponse falló. Revisá el registro saml para"
-" más detalles"
+"JIT no encontró un perfil para la asignación de entidades. Es posible que la "
+"asignación de perfiles no funcione.\n"
 
-#: src/LoginFlow/LoginFlowItem.php:110
-msgid "⭕ IDP ID must be a positive numeric value!"
-msgstr "⭕ ¡El ID del IDP debe ser un valor numérico positivo!"
+#: src/LoginFlow/User.php:541
+msgid "JIT found to be assigned profile(s) to be recursive.\n"
+msgstr "JIT encontró que el/los perfil(es) a asignar es/son recursivo/s.\n"
 
-#: src/LoginFlow/LoginFlowItem.php:113
-msgid "What IDP ID should be enforced?"
-msgstr "¿Qué ID del IDP debería ser forzado?"
+#: src/LoginFlow/User.php:543
+msgid "JIT didnt find to be assigned profile(s) to be recursive.\n"
+msgstr "JIT no encontró que el/los perfil(es) a asignar fuera/n recursivo/s.\n"
 
-#: src/LoginFlow/LoginFlowItem.php:114
-msgid "ENFORCED IDP ID"
-msgstr "ID DE IDP FORZADO"
+#: src/LoginFlow/User.php:560
+#, fuzzy
+msgid "JIT profile already assigned with config:"
+msgstr "JIT no pudo asignar el perfil con la configuración:"
 
-#: src/LoginFlow/LoginFlowItem.php:129
-msgid "Debug enabled?"
-msgstr "¿Depuración activada?"
+#: src/LoginFlow/User.php:566
+msgid "JIT was not able to assign profile with config:"
+msgstr "JIT no pudo asignar el perfil con la configuración:"
 
-#: src/LoginFlow/LoginFlowItem.php:140
-msgid ""
-"Should SAML SSO be enforced. This option can be bypassed by the bypass var "
-"and value"
+#: src/LoginFlow/User.php:572
+#, fuzzy
+msgid "JIT remove all default profiles from newly created user:\n"
 msgstr ""
-"Debería forzarse el SSO de SAML. Esta opción se puede omitir con la variable"
-" y el valor de omisión"
+"JIT elimina todos los perfiles existentes y por defecto del usuario recién "
+"creado:\n"
 
-#: src/LoginFlow/LoginFlowItem.php:141
-msgid "ENFORCE SSO"
-msgstr "FORZAR SSO"
+#: src/LoginFlow/User.php:580
+msgid "Done\n"
+msgstr "Hecho\n"
 
-#: src/LoginFlow/LoginFlowItem.php:151
-msgid "Try to match domain in username for IDP selection"
-msgstr ""
-"Intenta hacer coincidir el dominio en el nombre de usuario para la selección"
-" del IDP"
+#: src/LoginFlow/User.php:582
+msgid "failed\n"
+msgstr "falló\n"
 
-#: src/LoginFlow/LoginFlowItem.php:152
-msgid "ENABLE DOMAIN BASED SSO"
-msgstr "ACTIVAR SSO BASADO EN DOMINIO"
+#: src/LoginFlow/User.php:584
+msgid "JIT assigned profile with config:"
+msgstr "JIT asignó el perfil con la configuración:"
 
-#: src/LoginFlow/LoginFlowItem.php:162
-msgid "Allow the ?idpId=[val] URI to pre select IDP from URLs"
-msgstr "Permite que la URI ?idpId=[val] preseleccione el IDP desde las URL"
+#: src/LoginFlow/User.php:617
+msgid "JIT found default groupID:"
+msgstr "JIT encontró el ID de grupo por defecto:"
 
-#: src/LoginFlow/LoginFlowItem.php:163
-msgid "Enable getter login"
-msgstr "Activar getter de inicio de sesión"
+#: src/LoginFlow/User.php:619
+msgid "Jit didnt find a default GroupID to assign, skipping\n"
+msgstr "Jit no encontró un ID de Grupo por defecto para asignar, se omite\n"
 
-#: src/LoginFlow/LoginFlowItem.php:173
-msgid ""
-"Hide the default GLPI login options. This option can be bypassed using the "
-"bypass var and value."
-msgstr ""
-"Oculta las opciones de inicio de sesión por defecto de GLPI. Esta opción se "
-"puede omitir usando la variable y el valor de omisión."
+#: src/LoginFlow/User.php:624
+msgid "JIT found default entityID:"
+msgstr "JIT encontró el ID de entidad por defecto:"
 
-#: src/LoginFlow/LoginFlowItem.php:174
-msgid "HIDE GLPI LOGIN"
-msgstr "OCULTAR INICIO DE SESIÓN DE GLPI"
+#: src/LoginFlow/User.php:626
+msgid "Jit didnt find a default EntityId to assign, skipping\n"
+msgstr "Jit no encontró un Id de Entidad por defecto para asignar, se omite\n"
 
-#: src/LoginFlow/LoginFlowItem.php:184
-msgid ""
-"Hides Saml Buttons. This option cannot be used together with the Hide GLPI "
-"login."
-msgstr ""
-"Oculta los Botones Saml. Esta opción no se puede usar junto con Ocultar "
-"inicio de sesión de GLPI."
+#: src/LoginFlow/User.php:631
+msgid "JIT found default profileID:"
+msgstr "JIT encontró el ID de perfil por defecto:"
 
-#: src/LoginFlow/LoginFlowItem.php:185
-msgid "Hide Saml Buttons"
-msgstr "Ocultar Botones Saml"
+#: src/LoginFlow/User.php:633
+msgid "Jit didnt find a default ProfileId to assign, skipping\n"
+msgstr "Jit no encontró un Id de Perfil por defecto para asignar, se omite\n"
 
-#: src/LoginFlow/LoginFlowItem.php:195
-msgid "Hide the GLPI password field. To be used with Enable Domain Login."
-msgstr ""
-"Oculta el campo de contraseña de GLPI. Para ser usado con Activar Inicio de "
-"sesión con Dominio."
+#: src/LoginFlow/User.php:638
+#, fuzzy
+msgid "JIT found timezone:"
+msgstr "JIT encontró el ID de entidad por defecto:"
 
-#: src/LoginFlow/LoginFlowItem.php:196
-msgid "HIDE PASSWORD FIELD"
-msgstr "OCULTAR CAMPO DE CONTRASEÑA"
+#: src/LoginFlow/User.php:643
+#, fuzzy
+msgid "JIT found is_active:"
+msgstr "JIT encontró el ID de perfil por defecto:"
 
-#: src/LoginFlow/LoginFlowItem.php:206
-msgid "Forces samlSSO to (re)apply the rules on each succesfull auth."
-msgstr ""
-"Fuerza a samlSSO a (re)aplicar las reglas en cada autenticación exitosa."
+#: src/LoginFlow/User.php:648
+#, fuzzy
+msgid "JIT found locations_id:"
+msgstr "JIT encontró el ID de entidad por defecto:"
 
-#: src/LoginFlow/LoginFlowItem.php:207
-msgid "APPLY RULES ON AUTH"
-msgstr "APLICAR REGLAS EN AUTENTICACIÓN"
+#: src/LoginFlow/User.php:653
+#, fuzzy
+msgid "JIT found usercategories_id:"
+msgstr "JIT encontró el ID de perfil por defecto:"
+
+#: src/LoginFlow/User.php:658
+#, fuzzy
+msgid "JIT found usertitles_id:"
+msgstr "JIT encontró el ID de entidad por defecto:"
+
+#: src/LoginFlow/User.php:663
+#, fuzzy
+msgid "JIT found language:"
+msgstr "JIT encontró el ID de grupo por defecto:"
+
+#: src/LoginFlow/User.php:668
+msgid "Jit updated user defaults\n"
+msgstr "Jit actualizó los valores por defecto del usuario\n"
+
+#: src/LoginFlow/User.php:670
+msgid "Jit didnt update user defaults\n"
+msgstr "Jit no actualizó los valores por defecto del usuario\n"
 
 #: src/LoginFlow/Meta.php:76
-msgid "Error fetching spMetedata."
+#, fuzzy
+msgid "Error fetching spMetadata."
 msgstr "Error al obtener los Metadatos del sp."
 
 #: src/LoginFlow/Meta.php:81
@@ -870,252 +1145,422 @@ msgstr "Id inválido o metadatos no expuestos."
 msgid "Error fetching config."
 msgstr "Error al obtener la configuración."
 
-#: src/LoginFlow/User.php:165 src/LoginFlow/User.php:173
-msgid "User with GlpiUserid: "
-msgstr "Usuario con GlpiUserid: "
+#: src/LoginFlow/Acs.php:140
+msgid "Unable to fetch idp configuration with id:"
+msgstr "No se pudo obtener la configuración del idp con id:"
 
-#: src/LoginFlow/User.php:189
+#: src/LoginFlow/Acs.php:141
+msgid "Samlsso->acs->init->FetchConfig"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:156
+#, fuzzy, php-format
 msgid ""
-"Your SSO login was successful but we where not able to fetch\n"
-"                                            the loginState from the database and could not continue to log\n"
-"                                            you into GLPI."
+"The received idp response did not contain the required samlResponse POST "
+"body or idpId to authenticate the user, see: %s for more information"
 msgstr ""
-"Tu inicio de sesión SSO fue exitoso, pero no pudimos obtener\n"
-"                                            el loginState de la base de datos y no se pudo continuar con tu\n"
-"                                            inicio de sesión en GLPI."
+"La respuesta recibida del idp no contenía el cuerpo POST samlResponse o el "
+"idpId requeridos para autenticar al usuario. Consultá https://codeberg.org/"
+"QuinQuies/glpisaml/wiki/ACS.php para más información"
 
-#: src/LoginFlow/User.php:200
+#: src/LoginFlow/Acs.php:157
+msgid "Samlsso->acs->init->NoSamlResponse"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:179
+msgid "Samlsso->acs->init->phpsaml->Utils->setProxyVars"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:198
 msgid ""
-"Your SSO login was successful but there is no matching GLPI user account and\n"
-"                                                we failed to create one dynamically using Just In Time user creation. Please\n"
-"                                                request a GLPI administrator to review the logs and correct the problem or\n"
-"                                                request the administrator to create a GLPI user manually."
+"PHP-SAML could not initialize the settings object using the configEntity."
 msgstr ""
-"Tu inicio de sesión SSO fue exitoso, pero no hay una cuenta de usuario de GLPI coincidente y\n"
-"                                                fallamos al crear una dinámicamente usando la creación de usuarios Just In Time. Por favor,\n"
-"                                                solicitá a un administrador de GLPI que revise los registros y corrija el problema, o\n"
-"                                                pedile al administrador que cree un usuario de GLPI manualmente."
 
-#: src/LoginFlow/User.php:222
+#: src/LoginFlow/Acs.php:199
+msgid "Samlsso->acs->init->phpsaml->initializeSettings"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:207
+#, fuzzy
+msgid "PHP-SAML library could not process samlResponse and reported the error:"
+msgstr "No se pudo procesar la samlResponse con el Error:"
+
+#: src/LoginFlow/Acs.php:208
+msgid "Samlsso->acs->init->phpsaml->initializeResponse"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:227
+#, php-format
 msgid ""
-"Critical error: samlSSO was unable to fetch newly created user from the "
-"database!"
+"Could not fetch loginState from database with error: <br><br>%s<br><br>See: "
+"%s for more information."
 msgstr ""
-"Error crítico: ¡samlSSO no pudo obtener el usuario recién creado de la base "
-"de datos!"
 
-#: src/LoginFlow/User.php:239
-msgid "JIT was called with params:"
-msgstr "Se llamó a JIT con los parámetros:"
+#: src/LoginFlow/Acs.php:228
+msgid "Samlsso->acs->init->LoginState::construct"
+msgstr ""
 
-#: src/LoginFlow/User.php:250
-msgid "JIT failed to assign groupID:"
-msgstr "JIT falló al asignar el ID de grupo:"
-
-#: src/LoginFlow/User.php:252
-msgid "JIT assigned groupID:"
-msgstr "JIT asignó el ID de grupo:"
-
-#: src/LoginFlow/User.php:255
-msgid "JIT found no groupId to add.\n"
-msgstr "JIT no encontró ningún Id de grupo para agregar.\n"
-
-#: src/LoginFlow/User.php:269
-msgid "JIT found entity for profile assignment:"
-msgstr "JIT encontró la entidad para la asignación de perfiles:"
-
-#: src/LoginFlow/User.php:271
+#: src/LoginFlow/Acs.php:251
 msgid ""
-"JIT didnt find a profile for entity assignment. Profile asignment might not "
-"work.\n"
+"Validation of the samlResponse document failed. Review the saml log for more "
+"details"
 msgstr ""
-"JIT no encontró un perfil para la asignación de entidades. Es posible que la"
-" asignación de perfiles no funcione.\n"
+"La validación del documento samlResponse falló. Revisá el registro saml para "
+"más detalles"
 
-#: src/LoginFlow/User.php:277
-msgid "JIT found to be assigned profile(s) to be recursive.\n"
-msgstr "JIT encontró que el/los perfil(es) a asignar es/son recursivo/s.\n"
-
-#: src/LoginFlow/User.php:279
-msgid "JIT didnt find to be assigned profile(s) to be recursive.\n"
-msgstr "JIT no encontró que el/los perfil(es) a asignar fuera/n recursivo/s.\n"
-
-#: src/LoginFlow/User.php:283
-msgid "JIT remove all existing and default profiles from newly created user:\n"
+#: src/LoginFlow/Acs.php:252 src/LoginFlow/Acs.php:259
+msgid "Samlsso->acs->assertSaml->SamlResponse::isValid"
 msgstr ""
-"JIT elimina todos los perfiles existentes y por defecto del usuario recién "
-"creado:\n"
 
-#: src/LoginFlow/User.php:289
-msgid "Done\n"
-msgstr "Hecho\n"
-
-#: src/LoginFlow/User.php:291
-msgid "failed\n"
-msgstr "falló\n"
-
-#: src/LoginFlow/User.php:298
-msgid "JIT was not able to assign profile with config:"
-msgstr "JIT no pudo asignar el perfil con la configuración:"
-
-#: src/LoginFlow/User.php:300
-msgid "JIT assigned profile with config:"
-msgstr "JIT asignó el perfil con la configuración:"
-
-#: src/LoginFlow/User.php:313
-msgid "JIT found default groupID:"
-msgstr "JIT encontró el ID de grupo por defecto:"
-
-#: src/LoginFlow/User.php:315
-msgid "Jit didnt find a default GroupID to assign, skipping\n"
-msgstr "Jit no encontró un ID de Grupo por defecto para asignar, se omite\n"
-
-#: src/LoginFlow/User.php:320
-msgid "JIT found default entityID:"
-msgstr "JIT encontró el ID de entidad por defecto:"
-
-#: src/LoginFlow/User.php:322
-msgid "Jit didnt find a default EntityId to assign, skipping\n"
-msgstr "Jit no encontró un Id de Entidad por defecto para asignar, se omite\n"
-
-#: src/LoginFlow/User.php:327
-msgid "JIT found default profileID:"
-msgstr "JIT encontró el ID de perfil por defecto:"
-
-#: src/LoginFlow/User.php:329
-msgid "Jit didnt find a default ProfileId to assign, skipping\n"
-msgstr "Jit no encontró un Id de Perfil por defecto para asignar, se omite\n"
-
-#: src/LoginFlow/User.php:334
-msgid "Jit updated user defaults\n"
-msgstr "Jit actualizó los valores por defecto del usuario\n"
-
-#: src/LoginFlow/User.php:336
-msgid "Jit didnt update user defaults\n"
-msgstr "Jit no actualizó los valores por defecto del usuario\n"
-
-#: src/LoginFlow/User.php:380
-msgid "NameId attribute is missing in samlResponse"
-msgstr "El atributo NameId está faltando en la samlResponse"
-
-#: src/LoginFlow/User.php:389
+#: src/LoginFlow/Acs.php:258
+#, fuzzy
 msgid ""
-"Detected a default guest user in samlResponse, this is not supported<br>\n"
-"                                      by glpiSAML. Please create a dedicated account for this user owned by your\n"
-"                                      tenant/identity provider.<br>\n"
-"                                      Also see: https://learn.microsoft.com/en-us/azure/active-directory/develop/saml-claims-customization"
+"Validation of the samlResponse document failed with a critical error. Review "
+"the saml log for more details"
 msgstr ""
-"Se detectó un usuario invitado por defecto en la samlResponse; esto no es compatible<br> \n"
-"                                      con glpiSAML. Por favor, creá una cuenta dedicada para este usuario que sea propiedad de tu\n"
-"                                      inquilino/proveedor de identidad.<br> \n"
-"                                      Consultá también: https://learn.microsoft.com/en-us/azure/active-directory/develop/saml-claims-customization"
+"La validación del documento samlResponse falló. Revisá el registro saml para "
+"más detalles"
 
-#: src/LoginFlow/User.php:422
+#: src/LoginFlow/Acs.php:279
+#, fuzzy, php-format
 msgid ""
-"SamlResponse should have at least 1 valid email address for GLPI  to find\n"
-"                                          the corresponding GLPI user or create it (with JIT enabled). For this purpose make\n"
-"                                          sure either the IDP provided NameId property is populated with the email address format,\n"
-"                                          or configure the IDP to add the users email address in the samlResponse claims using\n"
-"                                          the designated schema property key:"
+"It looks like this samlResponse has already been used to authenticate a "
+"different user.\n"
+"                    Maybe an error occurred and you pressed F5 and "
+"accidently resend the samlResponse that is\n"
+"                    already registered as processed. For security reasons we "
+"can not allow processed samlResponses\n"
+"                    to be processed again. Please login again to generate a "
+"new samlResponse. Sorry for any inconvenience.\n"
+"                    If the problem presists, then please contact your "
+"administrator.\n"
+"                    See: %s for more information"
 msgstr ""
-"La SamlResponse debe tener al menos 1 dirección de correo electrónico válida para que GLPI pueda encontrar\n"
-"                                          al usuario de GLPI correspondiente o crearlo (con JIT activado). Para este propósito, asegurate\n"
-"                                          de que la propiedad NameId proporcionada por el IDP esté poblada con el formato de dirección de correo electrónico,\n"
-"                                          o configurá el IDP para agregar la dirección de correo electrónico del usuario en los claims de la samlResponse usando\n"
-"                                          la clave de propiedad de esquema designada:"
+"Parece que esta samlResponse ya fue usada para autenticar a un usuario "
+"diferente.\n"
+"                                 Quizás ocurrió un error y apretaste F5, "
+"reenviando accidentalmente la samlResponse que ya\n"
+"                                 está registrada como procesada. Por razones "
+"de seguridad, no podemos permitir que las samlResponses procesadas\n"
+"                                 se procesen de nuevo. Por favor, iniciá "
+"sesión otra vez para generar una nueva samlResponse. Disculpá las "
+"molestias.\n"
+"                                 Si el problema persiste, por favor, "
+"contactá a tu administrador.\n"
+"                                 Consultá: https://codeberg.org/QuinQuies/"
+"glpisaml/wiki/LoginState.php para más información"
 
-#: src/LoginFlow/User.php:446
+#: src/LoginFlow/Acs.php:285
+msgid "Samlsso->acs->assertSaml->LoginState::checkResponseIdUnique"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:306
 msgid ""
-"Provided firstname or givenname exceeded 255 characters. This claim should "
-"not be longer than 255 characters"
+"An error occured while trying to update the samlResponseId into the "
+"LoginState database. Review the saml log for more details"
 msgstr ""
-"El firstname o givenname proporcionado excedió los 255 caracteres. Este "
-"claim no debe ser mayor a 255 caracteres"
+"Ocurrió un error al intentar actualizar el samlResponseId en la base de "
+"datos de LoginState. Revisá el registro saml para más detalles"
 
-#: src/LoginFlow/User.php:457
+#: src/LoginFlow/Acs.php:307
+msgid "Samlsso->acs->assertSaml->LoginState::setSamlResponseId"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:320
+#, fuzzy, php-format
 msgid ""
-"Provided surname claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
+"GLPI did not expect an assertion from this Idp. The most likely reason is a "
+"race condition\n"
+"                    causing an inconsistant loginState in the database or "
+"software bug. Please login again via the\n"
+"                    GLPI-interface. Sorry for the inconvenience. See: %s\n"
+"                    for more information"
 msgstr ""
-"El claim de surname proporcionado excedió los 255 caracteres. Este claim no "
-"debe ser mayor a 255 caracteres"
+"GLPI no esperaba una aserción de este Idp. La razón más probable es una "
+"condición de carrera\n"
+"                                  que causa un loginState inconsistente en "
+"la base de datos o un bug de software. Por favor, iniciá sesión de nuevo a "
+"través de\n"
+"                                  la interfaz de GLPI. Disculpá las "
+"molestias. Consultá: https://codeberg.org/QuinQuies/glpisaml/wiki/"
+"LoginState.php\n"
+"                                  para más información"
 
-#: src/LoginFlow/User.php:470
+#: src/LoginFlow/Acs.php:324
+msgid "Samlsso->acs->assertSaml->PhaseMismatched"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:338
 msgid ""
-"Provided job title claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
+"An error occured while trying to update the login phase to "
+"LoginState::PHASE_SAML_AUTH  into the LoginState database.\n"
+"                                  Review the saml log for more details"
 msgstr ""
-"El claim de job title proporcionado excedió los 255 caracteres. Este claim "
-"no debe ser mayor a 255 caracteres"
+"Ocurrió un error al intentar actualizar la fase de inicio de sesión a "
+"LoginState::PHASE_SAML_AUTH en la base de datos de LoginState.\n"
+"                                  Revisá el registro saml para más detalles"
 
-#: src/LoginFlow/User.php:483
-msgid ""
-"Provided mobile phone number claim exceeded 255 characters. This claim "
-"should not be longer than 255 characters"
-msgstr ""
-"El claim de mobile phone number proporcionado excedió los 255 caracteres. "
-"Este claim no debe ser mayor a 255 caracteres"
+#: src/LoginFlow/Acs.php:339
+msgid "LoginState"
+msgstr "Estado de Inicio de sesión"
 
-#: src/LoginFlow/User.php:496
-msgid ""
-"Provided telephone phone number claim exceeded 255 characters. This claim "
-"should not be longer than 255 characters"
-msgstr ""
-"El claim de telephone phone number proporcionado excedió los 255 caracteres."
-" Este claim no debe ser mayor a 255 caracteres"
-
-#: src/LoginFlow/User.php:509
-msgid ""
-"Provided country claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
-msgstr ""
-"El claim de country proporcionado excedió los 255 caracteres. Este claim no "
-"debe ser mayor a 255 caracteres"
-
-#: src/LoginFlow/User.php:522
-msgid ""
-"Provided city claim exceeded 255 characters. This claim should not be longer"
-" than 255 characters"
-msgstr ""
-"El claim de city proporcionado excedió los 255 caracteres. Este claim no "
-"debe ser mayor a 255 caracteres"
-
-#: src/LoginFlow/User.php:535
-msgid ""
-"Provided street address claim exceeded 255 characters. This claim should not"
-" be longer than 255 characters"
-msgstr ""
-"El claim de street address proporcionado excedió los 255 caracteres. Este "
-"claim no debe ser mayor a 255 caracteres"
-
-#: src/LoginFlow/User.php:546
-msgid "Created by phpSaml Just-In-Time user creation on:"
-msgstr "Creado por la creación de usuarios Just-In-Time de phpSaml el:"
-
-#: src/LoginFlow/LoginFlowForm.php:69
+#: src/LoginFlow/LoginFlowForm.php:71
 msgid "Identity providers"
 msgstr "Proveedores de identidad"
 
-#: src/Exclude.php:124
+#: src/LoginFlow/LoginFlowForm.php:114
+msgid "Configuration invalid please correct all ⭕ errors first"
+msgstr ""
+"Configuración inválida; por favor, corregí primero todos los errores ⭕"
+
+#: src/LoginFlow/LoginFlowItem.php:120
+msgid "⭕ IDP ID must be a positive numeric value!"
+msgstr "⭕ ¡El ID del IDP debe ser un valor numérico positivo!"
+
+#: src/LoginFlow/LoginFlowItem.php:124
+msgid "What IDP ID should be enforced?"
+msgstr "¿Qué ID del IDP debería ser forzado?"
+
+#: src/LoginFlow/LoginFlowItem.php:125
+msgid "ENFORCED IDP ID"
+msgstr "ID DE IDP FORZADO"
+
+#: src/LoginFlow/LoginFlowItem.php:144
+msgid "Debug enabled?"
+msgstr "¿Depuración activada?"
+
+#: src/LoginFlow/LoginFlowItem.php:161
+msgid ""
+"Should SAML SSO be enforced. This option can be bypassed by the bypass var "
+"and value"
+msgstr ""
+"Debería forzarse el SSO de SAML. Esta opción se puede omitir con la variable "
+"y el valor de omisión"
+
+#: src/LoginFlow/LoginFlowItem.php:162
+msgid "ENFORCE SSO"
+msgstr "FORZAR SSO"
+
+#: src/LoginFlow/LoginFlowItem.php:178
+msgid "Try to match domain in username for IDP selection"
+msgstr ""
+"Intenta hacer coincidir el dominio en el nombre de usuario para la selección "
+"del IDP"
+
+#: src/LoginFlow/LoginFlowItem.php:179
+msgid "ENABLE DOMAIN BASED SSO"
+msgstr "ACTIVAR SSO BASADO EN DOMINIO"
+
+#: src/LoginFlow/LoginFlowItem.php:195
+msgid "Allow the ?idpId=[val] URI to pre select IDP from URLs"
+msgstr "Permite que la URI ?idpId=[val] preseleccione el IDP desde las URL"
+
+#: src/LoginFlow/LoginFlowItem.php:196
+msgid "Enable getter login"
+msgstr "Activar getter de inicio de sesión"
+
+#: src/LoginFlow/LoginFlowItem.php:212
+msgid ""
+"Hide the default GLPI login options. This option can be bypassed using the "
+"bypass var and value."
+msgstr ""
+"Oculta las opciones de inicio de sesión por defecto de GLPI. Esta opción se "
+"puede omitir usando la variable y el valor de omisión."
+
+#: src/LoginFlow/LoginFlowItem.php:213
+msgid "HIDE GLPI LOGIN"
+msgstr "OCULTAR INICIO DE SESIÓN DE GLPI"
+
+#: src/LoginFlow/LoginFlowItem.php:229
+msgid ""
+"Hides Saml Buttons. This option cannot be used together with the Hide GLPI "
+"login."
+msgstr ""
+"Oculta los Botones Saml. Esta opción no se puede usar junto con Ocultar "
+"inicio de sesión de GLPI."
+
+#: src/LoginFlow/LoginFlowItem.php:230
+msgid "Hide Saml Buttons"
+msgstr "Ocultar Botones Saml"
+
+#: src/LoginFlow/LoginFlowItem.php:246
+msgid "Hide the GLPI password field. To be used with Enable Domain Login."
+msgstr ""
+"Oculta el campo de contraseña de GLPI. Para ser usado con Activar Inicio de "
+"sesión con Dominio."
+
+#: src/LoginFlow/LoginFlowItem.php:247
+msgid "HIDE PASSWORD FIELD"
+msgstr "OCULTAR CAMPO DE CONTRASEÑA"
+
+#: src/LoginFlow/LoginFlowItem.php:263
+msgid "Forces samlSSO to (re)apply the rules on each succesfull auth."
+msgstr ""
+"Fuerza a samlSSO a (re)aplicar las reglas en cada autenticación exitosa."
+
+#: src/LoginFlow/LoginFlowItem.php:264
+msgid "APPLY RULES ON AUTH"
+msgstr "APLICAR REGLAS EN AUTENTICACIÓN"
+
+#: src/Exclude.php:126
 msgid "samlSSO Excludes"
 msgstr "Exclusiones de samlSSO"
 
-#: src/Exclude.php:146
+#: src/Exclude.php:149
 msgid "Agent contains"
 msgstr "Agente contiene"
 
-#: src/Exclude.php:152
+#: src/Exclude.php:155
 msgid "Bypass SAML auth"
 msgstr "Omitir autenticación SAML"
 
-#: src/Exclude.php:157
+#: src/Exclude.php:160
 msgid "Url contains path or file"
 msgstr "Url contiene ruta o archivo"
 
-#: src/Exclude.php:179
+#: src/Exclude.php:182
 msgid "Client Agent performing the call"
 msgstr "Agente Cliente que realiza la llamada"
 
-#: src/Exclude.php:188
+#: src/Exclude.php:191
 msgid "To be excluded path"
 msgstr "Ruta a excluir"
+
+#: src/RuleSaml.php:86
+msgid "JIT rules"
+msgstr "Reglas JIT"
+
+#: src/RuleSaml.php:153
+#, php-format
+msgid "SAML Claim: %s"
+msgstr ""
+
+#~ msgid "⚠️ Are you sure?"
+#~ msgstr "⚠️ ¿Estás seguro/a?"
+
+#~ msgid "Assert saml"
+#~ msgstr "Aserción saml"
+
+#~ msgid "phpSaml::Settings->init"
+#~ msgstr "phpSaml::Settings->init"
+
+#~ msgid "Saml::Response->init"
+#~ msgstr "Saml::Response->init"
+
+#~ msgid "Acs assertion"
+#~ msgstr "Aserción Acs"
+
+#~ msgid "samlResponse assertion"
+#~ msgstr "aserción de samlResponse"
+
+#~ msgid ""
+#~ "Your SSO login was successful but we where not able to fetch\n"
+#~ "                                            the loginState from the "
+#~ "database and could not continue to log\n"
+#~ "                                            you into GLPI."
+#~ msgstr ""
+#~ "Tu inicio de sesión SSO fue exitoso, pero no pudimos obtener\n"
+#~ "                                            el loginState de la base de "
+#~ "datos y no se pudo continuar con tu\n"
+#~ "                                            inicio de sesión en GLPI."
+
+#~ msgid ""
+#~ "Detected a default guest user in samlResponse, this is not supported<br>\n"
+#~ "                                      by glpiSAML. Please create a "
+#~ "dedicated account for this user owned by your\n"
+#~ "                                      tenant/identity provider.<br>\n"
+#~ "                                      Also see: https://"
+#~ "learn.microsoft.com/en-us/azure/active-directory/develop/saml-claims-"
+#~ "customization"
+#~ msgstr ""
+#~ "Se detectó un usuario invitado por defecto en la samlResponse; esto no es "
+#~ "compatible<br> \n"
+#~ "                                      con glpiSAML. Por favor, creá una "
+#~ "cuenta dedicada para este usuario que sea propiedad de tu\n"
+#~ "                                      inquilino/proveedor de identidad."
+#~ "<br> \n"
+#~ "                                      Consultá también: https://"
+#~ "learn.microsoft.com/en-us/azure/active-directory/develop/saml-claims-"
+#~ "customization"
+
+#~ msgid ""
+#~ "SamlResponse should have at least 1 valid email address for GLPI  to "
+#~ "find\n"
+#~ "                                          the corresponding GLPI user or "
+#~ "create it (with JIT enabled). For this purpose make\n"
+#~ "                                          sure either the IDP provided "
+#~ "NameId property is populated with the email address format,\n"
+#~ "                                          or configure the IDP to add the "
+#~ "users email address in the samlResponse claims using\n"
+#~ "                                          the designated schema property "
+#~ "key:"
+#~ msgstr ""
+#~ "La SamlResponse debe tener al menos 1 dirección de correo electrónico "
+#~ "válida para que GLPI pueda encontrar\n"
+#~ "                                          al usuario de GLPI "
+#~ "correspondiente o crearlo (con JIT activado). Para este propósito, "
+#~ "asegurate\n"
+#~ "                                          de que la propiedad NameId "
+#~ "proporcionada por el IDP esté poblada con el formato de dirección de "
+#~ "correo electrónico,\n"
+#~ "                                          o configurá el IDP para agregar "
+#~ "la dirección de correo electrónico del usuario en los claims de la "
+#~ "samlResponse usando\n"
+#~ "                                          la clave de propiedad de "
+#~ "esquema designada:"
+
+#~ msgid ""
+#~ "Provided firstname or givenname exceeded 255 characters. This claim "
+#~ "should not be longer than 255 characters"
+#~ msgstr ""
+#~ "El firstname o givenname proporcionado excedió los 255 caracteres. Este "
+#~ "claim no debe ser mayor a 255 caracteres"
+
+#~ msgid ""
+#~ "Provided surname claim exceeded 255 characters. This claim should not be "
+#~ "longer than 255 characters"
+#~ msgstr ""
+#~ "El claim de surname proporcionado excedió los 255 caracteres. Este claim "
+#~ "no debe ser mayor a 255 caracteres"
+
+#~ msgid ""
+#~ "Provided job title claim exceeded 255 characters. This claim should not "
+#~ "be longer than 255 characters"
+#~ msgstr ""
+#~ "El claim de job title proporcionado excedió los 255 caracteres. Este "
+#~ "claim no debe ser mayor a 255 caracteres"
+
+#~ msgid ""
+#~ "Provided mobile phone number claim exceeded 255 characters. This claim "
+#~ "should not be longer than 255 characters"
+#~ msgstr ""
+#~ "El claim de mobile phone number proporcionado excedió los 255 caracteres. "
+#~ "Este claim no debe ser mayor a 255 caracteres"
+
+#~ msgid ""
+#~ "Provided telephone phone number claim exceeded 255 characters. This claim "
+#~ "should not be longer than 255 characters"
+#~ msgstr ""
+#~ "El claim de telephone phone number proporcionado excedió los 255 "
+#~ "caracteres. Este claim no debe ser mayor a 255 caracteres"
+
+#~ msgid ""
+#~ "Provided country claim exceeded 255 characters. This claim should not be "
+#~ "longer than 255 characters"
+#~ msgstr ""
+#~ "El claim de country proporcionado excedió los 255 caracteres. Este claim "
+#~ "no debe ser mayor a 255 caracteres"
+
+#~ msgid ""
+#~ "Provided city claim exceeded 255 characters. This claim should not be "
+#~ "longer than 255 characters"
+#~ msgstr ""
+#~ "El claim de city proporcionado excedió los 255 caracteres. Este claim no "
+#~ "debe ser mayor a 255 caracteres"
+
+#~ msgid ""
+#~ "Provided street address claim exceeded 255 characters. This claim should "
+#~ "not be longer than 255 characters"
+#~ msgstr ""
+#~ "El claim de street address proporcionado excedió los 255 caracteres. Este "
+#~ "claim no debe ser mayor a 255 caracteres"

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -4,6 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # Translators:
+# Eduardo Mozart de Oliveira, 2026
 # Eduardo Peres, 2025
 # Rodrigo Leite, 2025
 #

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -2,135 +2,471 @@
 # Copyright (C) YEAR Chris Gralike
 # This file is distributed under the same license as the samlSSO package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Eduardo Peres, 2025
 # Rodrigo Leite, 2025
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: samlSSO 1.2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/DonutsNL/samlSSO/issues\n"
-"POT-Creation-Date: 2025-11-27 12:28+0100\n"
-"PO-Revision-Date: 2025-11-27 11:38+0000\n"
+"POT-Creation-Date: 2026-05-31 01:33-0300\n"
+"PO-Revision-Date: 2026-05-31 01:34-0300\n"
 "Last-Translator: Rodrigo Leite, 2025\n"
-"Language-Team: Portuguese (Brazil) (https://app.transifex.com/quinquies/teams/199875/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://app.transifex.com/quinquies/"
+"teams/199875/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
+"X-Generator: Poedit 3.9\n"
 
-#: hook.php:84
+#: hook.php:104
 msgid "samlSSO exclusions"
 msgstr "Exclusões samlSSO"
 
-#: hook.php:129
+#: hook.php:163
 msgid "🆗 Installing version:"
 msgstr "🆗 Instalando versão:"
 
-#: hook.php:133
+#: hook.php:187
+msgid ""
+"⚠️ PHP memory_limit is less than 512M. This may cause crashes during SAML "
+"Login. See: "
+msgstr ""
+"⚠️ PHP memory_limit é menor que 512M. Isso pode causar travamentos durante o "
+"Login SAML. Veja: "
+
+#: hook.php:198
 msgid "⚠️ OpenSSL not available, cant verify provided certificates"
 msgstr ""
 "⚠️ OpenSSL não disponível, impossivel verificar o certificado do provedor"
 
-#: hook.php:135
+#: hook.php:200
 msgid "🆗 OpenSSL found!"
 msgstr "🆗 OpenSSL encontrado!"
 
-#: setup.php:199
+#: setup.php:227
 msgid "Installed "
-msgstr "Instalado"
+msgstr "Instalado "
 
-#: src/RuleSaml.php:80
-msgid "JIT rules"
-msgstr "Regras JIT"
-
-#: src/RuleSamlCollection.php:73 src/Config.php:148
+#: src/RuleSamlCollection.php:73 src/Config.php:151
 msgid "JIT import rules"
 msgstr "Regras de Importação JIT"
 
-#: src/CronTask.php:65
-msgid "Clean old SAML sessions"
-msgstr "Limpar seções SAML antigas"
+#: src/LoginFlow.php:170
+msgid "samlFlow"
+msgstr "fluxo saml"
 
-#: src/CronTask.php:66
-msgid "SAML sessions retention period (in days, 0 for infinite)"
-msgstr "Tempo de retenção das seções SAML (em dias, 0 para ininito)"
+#: src/LoginFlow.php:258
+msgid "You have been forcefully logged out by an administrator."
+msgstr "Você foi desconectado forçadamente por um administrador."
 
-#: src/Config/ConfigItem.php:95 src/LoginFlow/LoginFlowItem.php:90
+#: src/LoginFlow.php:482
+msgid "Could not update the loginState and therefor stopped the loginFlow for:"
+msgstr ""
+"Não foi possível atualizar o estado de login e, portanto, o fluxo de login "
+"foi interrompido para:"
+
+#: src/LoginFlow.php:591
+#, php-format
+msgid ""
+"You have been authenticated using the SAML2 identity provider: <b>%1$s</b>."
+"<br><br>Because SAML authentication is enforced, logging out of GLPI locally "
+"will automatically log you back in immediately.<br><br>To sign out "
+"completely, please select <b>'Log out everywhere'</b>. Note that this will "
+"also terminate your active sessions in all other applications connected to "
+"this Identity Provider.<br><br>If you want to leave GLPI, just close this "
+"browser tab."
+msgstr ""
+"Você foi autenticado usando o provedor de identidade SAML2: <b>%1$s</b>."
+"<br><br>Como a autenticação SAML é imposta, sair localmente do GLPI irá "
+"automaticamente fazer com que você faça login novamente imediatamente."
+"<br><br>Para sair completamente, selecione <b>'Sair de todos os lugares'</"
+"b>. Observe que isso também encerrará suas sessões ativas em todas as outras "
+"aplicações conectadas a este Provedor de Identidade.<br><br>Se você quiser "
+"sair do GLPI, basta fechar esta aba do navegador."
+
+#: src/LoginFlow.php:596
+#, php-format
+msgid ""
+"You have been authenticated using the SAML2 identity provider: <b>%1$s</b>."
+"<br><br>You can log out permanently by also logging out with the IDP by "
+"pressing <b>'Log out everywhere'</b> (which terminates active sessions in "
+"all other applications depending on it), or perform a local logout from GLPI "
+"only by pressing <b>'Continue GLPI logout'</b>."
+msgstr ""
+"Você foi autenticado usando o provedor de identidade SAML2: <b>%1$s</b>."
+"<br><br>Você pode sair permanentemente fazendo logout também com o IDP ao "
+"pressionar <b>'Sair de todos os lugares'</b> (o que encerra as sessões "
+"ativas em todas as outras aplicações dependendo dele), ou realizando um "
+"logout local do GLPI apenas ao pressionar <b>'Continuar logout do GLPI'</b>."
+
+#: src/LoginFlow.php:603
+msgid "🤔 How do you like to proceed?"
+msgstr "🤔 Como você gostaria de prosseguir?"
+
+#: src/LoginFlow.php:606
+msgid "Continue with local logout"
+msgstr "Continuar logoff no GLPI"
+
+#: src/LoginFlow.php:608
+msgid "Close tab"
+msgstr "Fechar aba"
+
+#: src/LoginFlow.php:609
+msgid "Log out everywhere"
+msgstr "Sair de todas as seções"
+
+#: src/LoginFlow.php:663
+msgid "Login with external provider"
+msgstr "Login com provedor externo"
+
+#: src/LoginFlow.php:715 src/LoginFlow.php:775
+msgid "An internal error occurred. Please contact your GLPI administrator."
+msgstr ""
+"Ocorreu um erro interno. Por favor, entre em contato com o administrador do "
+"seu GLPI."
+
+#: src/LoginFlow.php:718
+msgid "⚠️ Sorry we are unable to log you in"
+msgstr "⚠️ Desculpe, não conseguimos efetuar o seu login"
+
+#: src/LoginFlow.php:723 src/LoginFlow.php:782
+msgid "Return to GLPI"
+msgstr "Voltar para o GLPI"
+
+#: src/LoginFlow.php:778
+msgid "⚠️ An error occurred"
+msgstr "⚠️ Ocorreu um erro"
+
+#: src/LoginFlow.php:779
+msgid "We are sorry, something went wrong while processing your request!"
+msgstr "Estamos lamentando, algo deu errado ao processar sua solicitação!"
+
+#: src/Config/ClaimMapItem.php:120
+msgid "IDP configuration ID must be a positive integer"
+msgstr "⭕ O ID do IDP deve ser um valor numérico positivo"
+
+#: src/Config/ClaimMapItem.php:140
+msgid "Invalid mapping target type"
+msgstr "Tipo de alvo de mapeamento inválido"
+
+#: src/Config/ClaimMapItem.php:162
+msgid "Invalid GLPI field selected for target type"
+msgstr "Tipo de mapeamento GLPI de campo inválido"
+
+#: src/Config/ClaimMapItem.php:182
+msgid "SAML Claim key cannot be empty"
+msgstr "A chave de reivindicação SAML não pode estar vazia"
+
+#: src/Config/ClaimMapItem.php:184
+msgid "SAML Claim key cannot exceed 255 characters"
+msgstr "A chave de reivindicação SAML não pode exceder 255 caracteres"
+
+#: src/Config/ClaimMapItem.php:204
+msgid "Default value must be a string"
+msgstr "O valor padrão deve ser uma string"
+
+#: src/Config/ClaimMapItem.php:206
+msgid "Default value cannot exceed 255 characters"
+msgstr "O valor padrão não pode exceder 255 caracteres"
+
+#: src/Config/ClaimMapEntity.php:310
+msgid "SAML Claim key cannot be empty for Username mapping."
+msgstr ""
+"A chave de reivindicação SAML não pode estar vazia para o mapeamento de "
+"Username."
+
+#: src/Config/ClaimMapEntity.php:318
+msgid "SAML Claim key cannot be empty for Email mapping."
+msgstr ""
+"A chave de reivindicação SAML não pode estar vazia para o mapeamento de "
+"Email."
+
+#: src/Config/ClaimMapEntity.php:357
+#, php-format
+msgid "Duplicate mapping for %s: %s"
+msgstr "Mapeamento duplicado para %s: %s"
+
+#: src/Config/ClaimMapEntity.php:373
+msgid "Username mapping is required and cannot be removed."
+msgstr "O mapeamento de Username é obrigatório e não pode ser removido."
+
+#: src/Config/ClaimMapEntity.php:377
+msgid "Email mapping is required and cannot be removed."
+msgstr "O mapeamento de Email é obrigatório e não pode ser removido."
+
+#: src/Config/ClaimMapEntity.php:480
+msgid "NameId attribute is missing in samlResponse"
+msgstr "O atributo NameId foi perdido em samlResponse"
+
+#: src/Config/ClaimMapEntity.php:486
+msgid ""
+"Detected a default guest user in samlResponse, this is not supported by "
+"glpiSAML."
+msgstr ""
+"Detectado um usuário guest padrão na resposta saml, isso não é suportado "
+"pelo glpiSAML."
+
+#: src/Config/ClaimMapEntity.php:531
+msgid ""
+"Warning: SAML NameId format was requested as email but observed value is not "
+"a valid email. Falling back to configured email field."
+msgstr ""
+"Aviso: O formato de NameId SAML foi solicitado como email, mas o valor "
+"observado não é um email válido. Voltando para o campo de email configurado."
+
+#: src/Config/ClaimMapEntity.php:554
+msgid "invalid values where used to identify the user during auth"
+msgstr ""
+"valores inválidos foram usados para identificar o usuário durante o login"
+
+#: src/Config/ClaimMapEntity.php:616
+#, php-format
+msgid "Required user field \"%s\" is missing or invalid in SAML response"
+msgstr ""
+"O campo de usuário obrigatório \"%s\" está ausente ou inválido na resposta "
+"SAML"
+
+#: src/Config/ClaimMapEntity.php:658
+msgid "Required rule field \"groups\" is missing in SAML response"
+msgstr "O campo de regra obrigatório \"groups\" está ausente na resposta SAML"
+
+#: src/Config/ClaimMapEntity.php:705
+#, php-format
+msgid "Required rule field \"%s\" is missing or invalid in SAML response"
+msgstr ""
+"O campo de regra obrigatório \"%s\" está ausente ou inválido na resposta SAML"
+
+#: src/Config/ConfigEntity.php:364
+msgid ""
+"⚠️ SP private key does not seem to match provided SP certificates modulus."
+msgstr ""
+"⚠️ A chave privada do SP parece não corresponder ao módulo dos certificados "
+"SP fornecidos."
+
+#: src/Config/ConfigEntity.php:369
+msgid ""
+"⚠️ Will be defaulted to \"No\" because the provided SP certificate does not "
+"look valid!"
+msgstr ""
+"⚠️ Será definido como \"Não\" por padrão, pois o certificado SP fornecido "
+"parece não ser válido!"
+
+#: src/Config/ConfigEntity.php:417
+msgid "⚠️ IDPs cannot be enforced if more than one is present in the IDP list."
+msgstr ""
+"⚠️ Os IDPs não podem ser impostos se mais de um estiver presente na lista de "
+"IDPs."
+
+#: src/Config/ConfigForm.php:255
+msgid "Restore failed: no valid backup file was uploaded."
+msgstr "Restauração falhou: nenhum arquivo de backup válido foi carregado."
+
+#: src/Config/ConfigForm.php:261
+msgid "Restore failed: unable to read the uploaded file."
+msgstr "Restauração falhou: não foi possível ler o arquivo carregado."
+
+#: src/Config/ConfigForm.php:298
+msgid "Restore failed: the backup file has an invalid or unrecognized format."
+msgstr ""
+"Restauração falhou: o arquivo de backup tem um formato inválido ou não "
+"reconhecido."
+
+#: src/Config/ConfigForm.php:338
+#, php-format
+msgid "Entry %d skipped: missing config block."
+msgstr "Entrada %d ignorada: bloco de configuração ausente."
+
+#: src/Config/ConfigForm.php:346
+#, php-format
+msgid "Entry %d skipped: missing or invalid id."
+msgstr "Entrada %d ignorada: ID ou inválido."
+
+#: src/Config/ConfigForm.php:364
+#, php-format
+msgid "Entry %d (%s) could not be inserted into database."
+msgstr "Entrada %d (%s) não pôde ser inserida no banco de dados."
+
+#: src/Config/ConfigForm.php:375
+#, php-format
+msgid "Config %s restored but claim mappings had validation errors."
+msgstr ""
+"Configuração %s restaurada, mas mapeamentos de reivindicações tiveram erros "
+"de validação."
+
+#: src/Config/ConfigForm.php:384
+#, php-format
+msgid "Restore successful: %d IDP configuration(s) restored."
+msgstr "Restauração bem-sucedida: %d configuração(s) IDP restaurada(s)."
+
+#: src/Config/ConfigForm.php:393
+msgid "Restore completed but no configurations were imported."
+msgstr "Restauração concluída, mas nenhuma configuração foi importada."
+
+#: src/Config/ConfigForm.php:411
+msgid "You do not have permission to perform this action."
+msgstr "Você não tem permissão para executar esta ação."
+
+#: src/Config/ConfigForm.php:426
+msgid "User disabled and session forced logoff."
+msgstr "Usuário desabilitado e logout forçado da sessão."
+
+#: src/Config/ConfigForm.php:428
+msgid "Login state session not found."
+msgstr "Estado de login da sessão não encontrado."
+
+#: src/Config/ConfigForm.php:517
+msgid "Successfully added new samlSSO configuration."
+msgstr "Nova configuração do samlSSO adicionada com sucesso."
+
+#: src/Config/ConfigForm.php:521
+msgid "Unable to add new samlSSO configuration, please review error logging"
+msgstr ""
+"Não foi possível adicionar uma nova configuração do samlSSO. Por favor, "
+"verifique o log de erros"
+
+#: src/Config/ConfigForm.php:526 src/Config/ConfigForm.php:571
+msgid "Configuration invalid, please correct all ⭕ errors first"
+msgstr ""
+"Configuração inválida, por favor corrija todos os erros marcados com ⭕ "
+"primeiro"
+
+#: src/Config/ConfigForm.php:562 src/LoginFlow/LoginFlowForm.php:105
+msgid "Configuration updated successfully"
+msgstr "Configuração atualizada com sucesso"
+
+#: src/Config/ConfigForm.php:566 src/LoginFlow/LoginFlowForm.php:109
+msgid "Configuration update failed, check your update rights or error logging"
+msgstr ""
+"A atualização da configuração falhou. Verifique suas permissões de "
+"atualização ou o log de erros"
+
+#: src/Config/ConfigForm.php:591
+msgid "Configuration deleted successfully"
+msgstr "Configuração apagada com sucesso"
+
+#: src/Config/ConfigForm.php:595
+msgid "Not allowed or error deleting SAML configuration!"
+msgstr "Não é permitido ou ocorreu um erro ao excluir a configuração SAML!"
+
+#: src/Config/ConfigForm.php:614 src/LoginFlow/LoginFlowForm.php:133
+msgid "Invalid request, redirecting back"
+msgstr "Solicitação inválida, redirecionando de volta"
+
+#: src/Config/ConfigForm.php:740
+msgid "This claim key has not been observed in any SAML responses yet."
+msgstr ""
+"Esta chave de reivindicação não foi observada em nenhuma resposta SAML."
+
+#: src/Config/ConfigForm.php:792 src/LoginFlow/LoginFlowForm.php:184
+msgid "Email Address"
+msgstr "Endereço de email"
+
+#: src/Config/ConfigForm.php:793 src/LoginFlow/LoginFlowForm.php:185
+msgid "Transient"
+msgstr "Transitório"
+
+#: src/Config/ConfigForm.php:794 src/LoginFlow/LoginFlowForm.php:186
+msgid "Persistent"
+msgstr "Persistente"
+
+#: src/Config/ConfigForm.php:795 src/LoginFlow/LoginFlowForm.php:189
+msgid "PasswordProtectedTransport"
+msgstr "Transporte protegido por senha"
+
+#: src/Config/ConfigForm.php:797 src/LoginFlow/LoginFlowForm.php:191
+msgid "X509"
+msgstr "X509"
+
+#: src/Config/ConfigForm.php:798 src/LoginFlow/LoginFlowForm.php:192
+msgid "none"
+msgstr "nenhum"
+
+#: src/Config/ConfigForm.php:799 src/LoginFlow/LoginFlowForm.php:195
+msgid "Exact"
+msgstr "Exato"
+
+#: src/Config/ConfigForm.php:802 src/LoginFlow/LoginFlowForm.php:198
+msgid "Better"
+msgstr "Melhor"
+
+#: src/Config/ConfigItem.php:101 src/LoginFlow/LoginFlowItem.php:97
 msgid "⭕ ID must be a positive numeric value!"
 msgstr "⭕ O ID deve ser um valor numérico positivo!"
 
-#: src/Config/ConfigItem.php:98 src/LoginFlow/LoginFlowItem.php:93
+#: src/Config/ConfigItem.php:105 src/LoginFlow/LoginFlowItem.php:101
 msgid "Unique identifier for this configuration"
 msgstr "Identificador único para esta configuração"
 
-#: src/Config/ConfigItem.php:99 src/LoginFlow/LoginFlowItem.php:94
+#: src/Config/ConfigItem.php:106 src/LoginFlow/LoginFlowItem.php:102
 msgid "CONFIG ID"
 msgstr "ID DA CONFIGURAÇÃO"
 
-#: src/Config/ConfigItem.php:112
+#: src/Config/ConfigItem.php:120
 msgid ""
-"This name is shown with the login button on the login page. Try to keep this"
-" name short en to the point."
+"This name is shown with the login button on the login page. Try to keep this "
+"name short en to the point."
 msgstr ""
-"Este nome é exibido junto ao botão de login na página de login. Tente manter"
-" este nome curto e objetivo."
+"Este nome é exibido junto ao botão de login na página de login. Tente manter "
+"este nome curto e objetivo."
 
-#: src/Config/ConfigItem.php:113
+#: src/Config/ConfigItem.php:121
 msgid "FRIENDLY NAME"
 msgstr "NOME AMIGÁVEL"
 
-#: src/Config/ConfigItem.php:118
+#: src/Config/ConfigItem.php:126
 msgid "⭕ Name is a required field"
 msgstr "⭕ Nome é um campo requerido"
 
-#: src/Config/ConfigItem.php:127
+#: src/Config/ConfigItem.php:137
 msgid "USERDOMAIN"
 msgstr "DOMINIO DO USUÁRIO"
 
-#: src/Config/ConfigItem.php:132
+#: src/Config/ConfigItem.php:142
 msgid "⭕ "
 msgstr "⭕ "
 
-#: src/Config/ConfigItem.php:147
+#: src/Config/ConfigItem.php:159
 msgid ""
 "⭕ Provided certificate does not like look a valid (base64 encoded) "
 "certificate"
 msgstr ""
 "⭕ O certificado informado não parece um certificado válido (codificação "
-"base64)."
+"base64)"
 
-#: src/Config/ConfigItem.php:151
+#: src/Config/ConfigItem.php:164
 msgid ""
 "The base64 encoded x509 service provider certificate. Used to sign and "
 "encrypt messages send by the service provider to the identity provider. "
 "Required for most of the security options"
 msgstr ""
-"O certificado do provedor de serviços X.509 codificado em Base64. Usado para"
-" assinar e criptografar mensagens enviadas pelo provedor de serviços ao "
-"provedor de identidade. Necessário para a maioria das opções de segurança."
+"O certificado do provedor de serviços X.509 codificado em Base64. Usado para "
+"assinar e criptografar mensagens enviadas pelo provedor de serviços ao "
+"provedor de identidade. Necessário para a maioria das opções de segurança"
 
-#: src/Config/ConfigItem.php:152
+#: src/Config/ConfigItem.php:165
 msgid "SP CERTIFICATE"
 msgstr "CERTIFICADO DO ISP"
 
-#: src/Config/ConfigItem.php:167
+#: src/Config/ConfigItem.php:182
 msgid ""
 "The base64 encoded x509 service providers private key. Should match the "
 "modulus of the provided X509 service provider certificate"
 msgstr ""
 "A chave privada do provedor de serviços X.509 codificada em base64 deve "
-"corresponder ao módulo do certificado do provedor de serviços X.509 "
-"fornecido."
+"corresponder ao módulo do certificado do provedor de serviços X.509 fornecido"
 
-#: src/Config/ConfigItem.php:168
+#: src/Config/ConfigItem.php:183
 msgid "SP PRIVATE KEY"
 msgstr "CHAVE PRIVADA DO ISP"
 
-#: src/Config/ConfigItem.php:179
+#: src/Config/ConfigItem.php:196
 msgid ""
 "The Service Provider nameid format specifies the constraints on the name "
 "identifier to be used to represent the requested subject."
@@ -138,15 +474,15 @@ msgstr ""
 "O formato nameid do provedor de serviços especifica as restrições sobre o "
 "identificador de nome a ser usado para representar o assunto solicitado."
 
-#: src/Config/ConfigItem.php:180
+#: src/Config/ConfigItem.php:197
 msgid "NAMEID FORMAT"
 msgstr "FORMATO DO NAMEID"
 
-#: src/Config/ConfigItem.php:185
+#: src/Config/ConfigItem.php:202
 msgid "Service provider name id is a required field"
 msgstr "Name ID do provedor é um campo obrigatório"
 
-#: src/Config/ConfigItem.php:192
+#: src/Config/ConfigItem.php:211
 msgid ""
 "Identifier of the IdP entity which is an URL provided by the SAML2 Identity "
 "Provider (IdP)"
@@ -154,24 +490,24 @@ msgstr ""
 "Identificador da entidade IdP, que é um URL fornecido pelo Provedor de "
 "Identidade SAML2 (IdP)."
 
-#: src/Config/ConfigItem.php:193
+#: src/Config/ConfigItem.php:212
 msgid "ENTITY ID"
 msgstr "ID DA ENTIDADE"
 
-#: src/Config/ConfigItem.php:198
+#: src/Config/ConfigItem.php:217
 msgid "⭕ Identity provider entity id is a required field"
 msgstr "⭕ O ID da entidade do provedor de identidade é um campo obrigatório"
 
-#: src/Config/ConfigItem.php:211
+#: src/Config/ConfigItem.php:231
 msgid "⭕ The IdP SSO URL is a required field!<br>"
-msgstr "⭕ A URL de SSO do IdP é um campo obrigatório!"
+msgstr "⭕ A URL de SSO do IdP é um campo obrigatório!<br>"
 
-#: src/Config/ConfigItem.php:216
+#: src/Config/ConfigItem.php:236
 msgid "⭕ Invalid IdP SSO URL, use: scheme://host.domain.tld/path/"
 msgstr ""
 "⭕ A URL de SSO do IDP é inválida, use: esquema://host.dominio.tld/caminho/"
 
-#: src/Config/ConfigItem.php:223
+#: src/Config/ConfigItem.php:244
 msgid ""
 "Single Sign On Service endpoint of the IdP. URL Target of the IdP where the "
 "Authentication Request Message will be sent. OneLogin PHPSAML only supports "
@@ -179,53 +515,53 @@ msgid ""
 msgstr ""
 "O ponto de extremidade do serviço Single Sign-On (SSO) do IDP. URL de "
 "destino do IDP para onde a mensagem de solicitação de autenticação será "
-"enviada. O OneLogin PHPSAML suporta apenas o redirecionamento HTTP para este"
-" ponto de extremidade."
+"enviada. O OneLogin PHPSAML suporta apenas o redirecionamento HTTP para este "
+"ponto de extremidade."
 
-#: src/Config/ConfigItem.php:224
+#: src/Config/ConfigItem.php:245
 msgid "SSO URL"
 msgstr "URL de SSO"
 
-#: src/Config/ConfigItem.php:246
+#: src/Config/ConfigItem.php:268
 msgid "⭕ Invalid Idp SLO URL, use: scheme://host.domain.tld/path/"
 msgstr ""
 "⭕ A URL SLO do IDP é inválida, use: esquema://host.dominio.tld/caminho/"
 
-#: src/Config/ConfigItem.php:249
+#: src/Config/ConfigItem.php:272
 msgid ""
-"Single Logout service endpoint of the IdP. URL Location of the IdP where SLO"
-" Request will be sent.OneLogin PHPSAML only supports the 'HTTP-redirect' "
+"Single Logout service endpoint of the IdP. URL Location of the IdP where SLO "
+"Request will be sent.OneLogin PHPSAML only supports the 'HTTP-redirect' "
 "binding for this endpoint."
 msgstr ""
-"Ponto de extremidade do serviço Single Logout (SLO) do IDP. Localização da "
-"URL do IDP para onde a solicitação SLO será enviada. O OneLogin PHPSAML "
-"suporta apenas o redirecionamento HTTP para este ponto de extremidade."
+"Endpoint do serviço Single Logout (SLO) do IDP. Localização da URL do IDP "
+"para onde a solicitação SLO será enviada. O OneLogin PHPSAML suporta apenas "
+"o redirecionamento HTTP para este ponto de extremidade."
 
-#: src/Config/ConfigItem.php:250
+#: src/Config/ConfigItem.php:273
 msgid "SLO URL"
 msgstr "URL de SLO"
 
-#: src/Config/ConfigItem.php:269
+#: src/Config/ConfigItem.php:294
 msgid "⭕ Valid Idp X509 certificate is required! (base64 encoded)"
 msgstr "⭕ É necessário um certificado IdP X509 válido! (codificado em base64)"
 
-#: src/Config/ConfigItem.php:273
+#: src/Config/ConfigItem.php:299
 msgid ""
 "The Public Base64 encoded x509 certificate used by the IdP. Fingerprinting "
-"can be used, but is not recommended. Fingerprinting requires you to manually"
-" alter the Saml Config array located in ConfigEntity.php and provide the "
+"can be used, but is not recommended. Fingerprinting requires you to manually "
+"alter the Saml Config array located in ConfigEntity.php and provide the "
 "required configuration options"
 msgstr ""
 "O certificado público x509 codificado em Base64 usado pelo IDP. A impressão "
-"digital pode ser usada, mas não é recomendada. A impressão digital exige que"
-" você altere manualmente o array de configuração SAML localizado em "
-"ConfigEntity.php e forneça as opções de configuração necessárias."
+"digital pode ser usada, mas não é recomendada. A impressão digital exige que "
+"você altere manualmente o array de configuração SAML localizado em "
+"ConfigEntity.php e forneça as opções de configuração necessárias"
 
-#: src/Config/ConfigItem.php:274
+#: src/Config/ConfigItem.php:300
 msgid "X509 CERTIFICATE"
 msgstr "CERTIFICADO X509"
 
-#: src/Config/ConfigItem.php:299
+#: src/Config/ConfigItem.php:327
 msgid ""
 "Authentication context needs to be satisfied by the IdP in order to allow "
 "Saml login. Set to \"none\" and OneLogin PHPSAML will not send an "
@@ -237,116 +573,121 @@ msgstr ""
 "AuthContext na solicitação AuthNRequest. Ou selecione uma ou mais opções "
 "usando a combinação \"control+clique\"."
 
-#: src/Config/ConfigItem.php:300
+#: src/Config/ConfigItem.php:328
 msgid "REQ AUTHN CONTEXT"
-msgstr "CONTEXTO DE AUTENTICAÇÃO SOLICITADO"
+msgstr "CONTEXTO DE REQ AUTHN"
 
-#: src/Config/ConfigItem.php:305
+#: src/Config/ConfigItem.php:333
 msgid "⭕ Requested authN context is a required field"
 msgstr "⭕ O contexto de autenticação solicitado é um campo obrigatório"
 
-#: src/Config/ConfigItem.php:310
+#: src/Config/ConfigItem.php:340
 msgid "AUTHN Comparison attribute value"
 msgstr "Valor do atributo de comparação AUTHN"
 
-#: src/Config/ConfigItem.php:311
+#: src/Config/ConfigItem.php:341
 msgid "AUTHN COMPARISON"
 msgstr "COMPARAÇÃO DE AUTENTICAÇÃO"
 
-#: src/Config/ConfigItem.php:316
+#: src/Config/ConfigItem.php:346
 msgid "⭕ Requested authN context comparison is a required field"
 msgstr ""
 "⭕ A comparação do contexto de autenticação solicitado é um campo obrigatório"
 
-#: src/Config/ConfigItem.php:321
-msgid ""
-"The FontAwesome (https://fontawesome.com/) icon to show on the button on the"
-" login page."
+#: src/Config/ConfigItem.php:353
+#, php-format
+msgid "The FontAwesome (%s) icon to show on the button on the login page."
 msgstr ""
-"O ícone do FontAwesome (https://fontawesome.com/) deve ser exibido no botão "
-"da página de login."
+"O ícone do FontAwesome (%s) deve ser exibido no botão da página de login."
 
-#: src/Config/ConfigItem.php:322
+#: src/Config/ConfigItem.php:354
 msgid "LOGIN ICON"
 msgstr "ÍCONE DE LOGIN"
 
-#: src/Config/ConfigItem.php:327
+#: src/Config/ConfigItem.php:359
 msgid "⭕ Configuration icon is a required field"
 msgstr "⭕ Ícone de configuração é um campo obrigatório"
 
-#: src/Config/ConfigItem.php:332
+#: src/Config/ConfigItem.php:366
 msgid "The comments"
 msgstr "Os comentários"
 
-#: src/Config/ConfigItem.php:333
+#: src/Config/ConfigItem.php:367
 msgid "COMMENTS"
 msgstr "COMENTÁRIOS"
 
-#: src/Config/ConfigItem.php:344
-msgid "The date this configuration item was created"
-msgstr "A data em que este item de configuração foi criado."
+#: src/Config/ConfigItem.php:379
+msgid "The anonymized SAML response XML structure"
+msgstr "A estrutura XML de resposta SAML anonimizada"
 
-#: src/Config/ConfigItem.php:345
+#: src/Config/ConfigItem.php:380
+msgid "SAML Response XML Structure"
+msgstr "Estrutura XML de Resposta SAML"
+
+#: src/Config/ConfigItem.php:393
+msgid "The date this configuration item was created"
+msgstr "A data em que este item de configuração foi criado"
+
+#: src/Config/ConfigItem.php:394
 msgid "CREATE DATE"
 msgstr "DATA DE CRIAÇÃO"
 
-#: src/Config/ConfigItem.php:357
+#: src/Config/ConfigItem.php:408
 msgid "The date this config was modified"
-msgstr "A data em que este item de configuração foi modificado."
+msgstr "A data em que este item de configuração foi modificado"
 
-#: src/Config/ConfigItem.php:358
+#: src/Config/ConfigItem.php:409
 msgid "MODIFICATION DATE"
 msgstr "DATA DE MODIFICAÇÃO"
 
-#: src/Config/ConfigItem.php:373
+#: src/Config/ConfigItem.php:429
 msgid "Is this configuration marked as deleted by GLPI"
-msgstr "Esta configuração foi marcada como excluída pelo GLPI?"
+msgstr "Esta configuração foi marcada como excluída pelo GLPI"
 
-#: src/Config/ConfigItem.php:374
+#: src/Config/ConfigItem.php:430
 msgid "IS DELETED"
 msgstr "ESTÁ DELETADO"
 
-#: src/Config/ConfigItem.php:382
+#: src/Config/ConfigItem.php:442
 msgid ""
-"Indicates if this configuration activated. Disabled configurations cannot be"
-" used to login into GLPI and will NOT be shown on the login page."
+"Indicates if this configuration activated. Disabled configurations cannot be "
+"used to login into GLPI and will NOT be shown on the login page."
 msgstr ""
 "Indica se esta configuração está ativada. Configurações desativadas não "
 "podem ser usadas para fazer login no GLPI e NÃO serão exibidas na página de "
 "login."
 
-#: src/Config/ConfigItem.php:383
+#: src/Config/ConfigItem.php:443
 msgid "IS ACTIVE"
 msgstr "ESTÁ ATIVO"
 
-#: src/Config/ConfigItem.php:391
+#: src/Config/ConfigItem.php:455
 msgid ""
-"If enabled PHPSAML will replace the default GLPI login screen with a version"
-" that does not have the default GLPI login options and only allows the user "
+"If enabled PHPSAML will replace the default GLPI login screen with a version "
+"that does not have the default GLPI login options and only allows the user "
 "to authenticate using the configured SAML2 idps. This setting can be "
 "bypassed using a bypass URI parameter"
 msgstr ""
 "Se ativado, o PHPSAML substituirá a tela de login padrão do GLPI por uma "
 "versão que não possui as opções de login padrão do GLPI e permite que o "
 "usuário se autentique apenas usando os IDPs SAML2 configurados. Essa "
-"configuração pode ser ignorada usando um parâmetro de URI de bypass."
+"configuração pode ser ignorada usando um parâmetro de URI de bypass"
 
-#: src/Config/ConfigItem.php:392
+#: src/Config/ConfigItem.php:456
 msgid "ENFORCED"
-msgstr "APLICADO"
+msgstr "ENFORÇADO"
 
-#: src/Config/ConfigItem.php:400
-msgid ""
-"Is GLPI positioned behind a proxy that alters the SAML response scheme?"
+#: src/Config/ConfigItem.php:468
+msgid "Is GLPI positioned behind a proxy that alters the SAML response scheme?"
 msgstr ""
 "O GLPI está posicionado atrás de um proxy que altera o esquema de resposta "
 "SAML?"
 
-#: src/Config/ConfigItem.php:401
+#: src/Config/ConfigItem.php:469
 msgid "REQUESTS PROXIED"
-msgstr "SOLICITAÇÕES PROXIADAS"
+msgstr "REQUISIÇÕES PROXIADAS"
 
-#: src/Config/ConfigItem.php:409
+#: src/Config/ConfigItem.php:481
 msgid ""
 "If enabled the OneLogin PHPSAML Toolkit will reject unsigned or unencrypted "
 "messages if it expects them to be signed or encrypted. Also it will reject "
@@ -355,16 +696,16 @@ msgid ""
 "environments."
 msgstr ""
 "Se ativado, o OneLogin PHPSAML Toolkit rejeitará mensagens não assinadas ou "
-"não criptografadas caso espere que sejam assinadas ou criptografadas. Também"
-" rejeitará mensagens se o padrão SAML não for rigorosamente seguido: "
-"Destino, NameId e Condições também são validados. Altamente recomendado em "
-"ambientes de produção."
+"não criptografadas caso espere que sejam assinadas ou criptografadas. Também "
+"rejeitará mensagens se o padrão SAML não for rigorosamente seguido: Destino, "
+"NameId e Condições também são validados. Altamente recomendado em ambientes "
+"de produção."
 
-#: src/Config/ConfigItem.php:410
+#: src/Config/ConfigItem.php:482
 msgid "STRICT"
 msgstr "ESTRITO"
 
-#: src/Config/ConfigItem.php:418
+#: src/Config/ConfigItem.php:494
 msgid ""
 "If enabled it will enforce OneLogin PHPSAML to print status and error "
 "messages. Be aware that not all message's might be captured by samlSSO and "
@@ -374,7 +715,7 @@ msgstr ""
 "status e erro. Observe que nem todas as mensagens podem ser capturadas pelo "
 "samlSSO e, portanto, podem não ser exibidas."
 
-#: src/Config/ConfigItem.php:427
+#: src/Config/ConfigItem.php:507
 msgid ""
 "If enabled samlSSO will create new GLPI users on the fly and assign the "
 "properties defined in the samlSSO assignment rules. If disables users that "
@@ -386,27 +727,100 @@ msgstr ""
 "desativado, os usuários que não possuírem uma conta válida no GLPI não "
 "poderão acessar o sistema até que uma conta seja criada manualmente."
 
-#: src/Config/ConfigItem.php:428
+#: src/Config/ConfigItem.php:508
 msgid "JIT USER CREATION"
 msgstr "CRIAÇÃO DE USUÁRIOS JIT"
 
-#: src/Config/ConfigItem.php:436
+#: src/Config/ConfigItem.php:526
+msgid ""
+"If enabled, user fields mapped from SAML claims and assignment rules will be "
+"synchronized on every successful login."
+msgstr ""
+"Se ativado, os campos de usuário mapeados de reivindicações SAML e regras de "
+"atribuição serão sincronizados a cada login bem-sucedido."
+
+#: src/Config/ConfigItem.php:527
+msgid "SYNC ON LOGIN"
+msgstr "SINCRONIZAR NO LOGIN"
+
+#: src/Config/ConfigItem.php:545
+msgid ""
+"If enabled, GLPI will require all SAML protocol messages received from the "
+"Identity Provider (IdP) to be cryptographically signed."
+msgstr ""
+"Se ativado, o GLPI exigirá que todas as mensagens do protocolo SAML "
+"recebidas do Provedor de Identidade (IdP) sejam criptografadas."
+
+#: src/Config/ConfigItem.php:546
+msgid "REQUIRE SIGNED MESSAGES"
+msgstr "EXIGIR MENSAGENS ASSINADAS"
+
+#: src/Config/ConfigItem.php:564
+msgid ""
+"If enabled, GLPI will require individual SAML assertions within the SAML "
+"message to be signed. If unsigned, assertions will be rejected."
+msgstr ""
+"Se ativado, o GLPI exigirá que as afirmações SAML individuais dentro da "
+"mensagem SAML sejam assinadas. Asserções não assinadas serão rejeitadas."
+
+#: src/Config/ConfigItem.php:565
+msgid "REQUIRE SIGNED ASSERTIONS"
+msgstr "EXIGIR ASSERTAÇÕES ASSINADAS"
+
+#: src/Config/ConfigItem.php:583
+msgid ""
+"If enabled, GLPI will expect the SAML assertions containing user claims to "
+"be encrypted. GLPI will decrypt them using the SP private key."
+msgstr ""
+"Se ativado, o GLPI espera que as afirmações SAML contendo reivindicações de "
+"usuário sejam criptografadas. O GLPI as descriptografará usando a chave "
+"privada do SP."
+
+#: src/Config/ConfigItem.php:584
+msgid "REQUIRE ENCRYPTED ASSERTIONS"
+msgstr "EXIGIR ASSERTAÇÕES CRIPTOGRAFADAS"
+
+#: src/Config/ConfigItem.php:602
+msgid ""
+"If enabled, the SAML SP metadata XML generated by GLPI will be "
+"cryptographically signed using the Service Provider certificate."
+msgstr ""
+"Se ativado, o XML de metadados SP SAML gerado pelo GLPI será criptografado "
+"usando o certificado do Provedor de Serviço."
+
+#: src/Config/ConfigItem.php:603
+msgid "SIGN SP METADATA"
+msgstr "ASSINAR METADADOS"
+
+#: src/Config/ConfigItem.php:621
+msgid ""
+"If enabled, GLPI will strictly require a NameID element to be present in the "
+"SAML assertion payload."
+msgstr ""
+"Se ativado, o GLPI exigirá estritamente um elemento NameID presente no "
+"payload da afirmação SAML."
+
+#: src/Config/ConfigItem.php:622
+msgid "REQUIRE NAMEID"
+msgstr "REQUER NAMEID"
+
+#: src/Config/ConfigItem.php:634
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will encrypt the "
 "<samlp:logoutRequest> sent by this SP using the provided SP certificate and "
 "private key. This option will be toggled \"off\" automatically if no, or no "
 "valid SP certificate and key is provided."
 msgstr ""
-"Se ativada, a ferramenta PHPSAML do OneLogin criptografará os dados enviados"
-" por este provedor de serviços usando o certificado e a chave privada "
-"fornecidos. Esta opção será desativada automaticamente se nenhum certificado"
-" e chave de provedor de serviços válidos forem fornecidos."
+"Se ativada, a ferramenta PHPSAML do OneLogin criptografará os dados enviados "
+"por este provedor de serviços usando o certificado e a chave privada "
+"fornecidos. Esta opção será desativada automaticamente se nenhum certificado "
+"e chave de provedor de serviços válidos forem fornecidos."
 
-#: src/Config/ConfigItem.php:437
+#: src/Config/ConfigItem.php:635
 msgid "ENCRYPT NAMEID"
-msgstr "CRIPTOGRAFAR NOMEID"
+msgstr "CRIPTOGRAFAR NAMEID"
 
-#: src/Config/ConfigItem.php:445
+#: src/Config/ConfigItem.php:647
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will sign the <samlp:AuthnRequest> "
 "messages send by this SP. The IDP should consult the metadata to get the "
@@ -416,11 +830,11 @@ msgstr ""
 "enviadas por este SP. O IDP deve consultar os metadados para obter as "
 "informações necessárias para validar as assinaturas."
 
-#: src/Config/ConfigItem.php:446
+#: src/Config/ConfigItem.php:648
 msgid "SIGN AUTHN REQUEST"
 msgstr "ASSINAR SOLICITAÇÃO DE AUTENTICAÇÃO"
 
-#: src/Config/ConfigItem.php:454
+#: src/Config/ConfigItem.php:660
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutRequest> "
 "messages send by this SP."
@@ -428,57 +842,58 @@ msgstr ""
 "Se ativado, o kit de ferramentas PHPSAML do OneLogin assinará as mensagens "
 "enviadas por este provedor de serviços."
 
-#: src/Config/ConfigItem.php:455
+#: src/Config/ConfigItem.php:661
 msgid "SIGN LOGOUT REQUEST"
 msgstr "ASSINAR PEDIDO DE DESCONECTAR"
 
-#: src/Config/ConfigItem.php:463
+#: src/Config/ConfigItem.php:673
 msgid ""
-"If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutResponse>"
-" messages send by this SP."
+"If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutResponse> "
+"messages send by this SP."
 msgstr ""
 "Se ativado, o kit de ferramentas PHPSAML do OneLogin assinará as mensagens "
 "enviadas por este provedor de serviços."
 
-#: src/Config/ConfigItem.php:464
+#: src/Config/ConfigItem.php:674
 msgid "SIGN LOGOUT RESPONSE"
 msgstr "RESPOSTA DE LOGOUT"
 
-#: src/Config/ConfigItem.php:472
+#: src/Config/ConfigItem.php:686
 msgid ""
-"If enabled the authentication requests send to the IdP will be compressed by"
-" the SP."
+"If enabled the authentication requests send to the IdP will be compressed by "
+"the SP."
 msgstr ""
-"Se ativada, a opção de compactação das solicitações de autenticação enviadas"
-" ao IDP será implementada pelo SP."
+"Se ativada, a opção de compactação das solicitações de autenticação enviadas "
+"ao IDP será implementada pelo SP."
 
-#: src/Config/ConfigItem.php:473
+#: src/Config/ConfigItem.php:687
 msgid "COMPRESS REQUESTS"
-msgstr "SOLICITAÇÕES DE COMPRESSÃO"
+msgstr "REQUISIÇÕES DE COMPRESSÃO"
 
-#: src/Config/ConfigItem.php:481
+#: src/Config/ConfigItem.php:699
 msgid "If enabled the SP expects responses send by the IdP to be compressed."
 msgstr ""
-"Se ativado, o SP espera que as respostas enviadas pelo IDP sejam "
-"compactadas."
+"Se ativado, o SP espera que as respostas enviadas pelo IDP sejam compactadas."
 
-#: src/Config/ConfigItem.php:482
+#: src/Config/ConfigItem.php:700
 msgid "COMPRESS RESPONSES"
 msgstr "RESPOSTAS DE COMPRESSÃO"
 
-#: src/Config/ConfigItem.php:490
+#: src/Config/ConfigItem.php:712
 msgid ""
-"If enabled the SP will validate all received XMLs. In order to validate the XML\n"
-"                                                        \"strict\" security setting must be true."
+"If enabled the SP will validate all received XMLs. In order to validate the "
+"XML\n"
+"                                                        \"strict\" security "
+"setting must be true."
 msgstr ""
 "Se ativado, o SP validará todos os XMLs recebidos. Para validar o XML, a "
 "configuração de segurança \"estrita\" deve estar definida como verdadeira."
 
-#: src/Config/ConfigItem.php:492
+#: src/Config/ConfigItem.php:714
 msgid "VALIDATE XML"
 msgstr "VALIDAR XML"
 
-#: src/Config/ConfigItem.php:500
+#: src/Config/ConfigItem.php:726
 msgid ""
 "If enabled, SAMLResponses with an empty value at its Destination attribute "
 "will not be rejected for this fact."
@@ -486,388 +901,270 @@ msgstr ""
 "Se ativada, a opção fará com que as respostas SAML com um valor vazio no "
 "atributo Destination não sejam rejeitadas por esse motivo."
 
-#: src/Config/ConfigItem.php:501
+#: src/Config/ConfigItem.php:727
 msgid "RELAX DEST VALIDATION"
-msgstr "FRAGILIZE A VALIDAÇÃO DO DESTINO"
+msgstr "RELAXAR A VALIDAÇÃO DO DESTINO"
 
-#: src/Config/ConfigItem.php:509
+#: src/Config/ConfigItem.php:739
 msgid ""
-"ADFS URL-Encodes SAML data as lowercase, and the OneLogin PHPSAML toolkit by"
-" default uses uppercase. Enable this setting for ADFS compatibility on "
+"ADFS URL-Encodes SAML data as lowercase, and the OneLogin PHPSAML toolkit by "
+"default uses uppercase. Enable this setting for ADFS compatibility on "
 "signature verification"
 msgstr ""
 "O ADFS codifica os dados SAML em URLs em minúsculas, enquanto o kit de "
 "ferramentas PHPSAML do OneLogin usa maiúsculas por padrão. Habilite esta "
-"configuração para compatibilidade com o ADFS na verificação de assinatura."
+"configuração para compatibilidade com o ADFS na verificação de assinatura"
 
-#: src/Config/ConfigItem.php:510
+#: src/Config/ConfigItem.php:740
 msgid "LOWER CASE ENCODING"
 msgstr "CODIFICAÇÃO EM MINÚSCULAS"
 
-#: src/Config/ConfigItem.php:564
+#: src/Config/ConfigItem.php:800
 msgid ""
 "⚠️ Warning, do not use the 'withlove.from.donuts.nl' example certificates. "
 "They offer no additional protection."
 msgstr ""
-"⚠️ Cuidado, não use os certificados de exemplo do 'withlove.from.donuts.nl'."
-" Eles não oferecem nenhuma proteção adicional."
+"⚠️ Cuidado, não use os certificados de exemplo do 'withlove.from.donuts.nl'. "
+"Eles não oferecem nenhuma proteção adicional."
 
-#: src/Config/ConfigItem.php:572
+#: src/Config/ConfigItem.php:810
 msgid ""
-"⭕ Certificate must be wrapped in valid BEGIN CERTIFICATE and END CERTIFICATE"
-" tags"
+"⭕ Certificate must be wrapped in valid BEGIN CERTIFICATE and END "
+"CERTIFICATE tags"
 msgstr ""
 "⭕ O certificado deve estar envolto em etiquetas válidas de INÍCIO DO "
-"CERTIFICADO e FIM DO CERTIFICADO."
+"CERTIFICADO e FIM DO CERTIFICADO"
 
-#: src/Config/ConfigItem.php:576
+#: src/Config/ConfigItem.php:816
 msgid "⭕ Certificate should not contain \"carriage returns\" [<CR>]"
 msgstr "⭕ O certificado não deve conter \"quebras de linha\" [1]"
 
-#: src/Config/ConfigItem.php:580
+#: src/Config/ConfigItem.php:820
 msgid "⭕ No valid X509 certificate found"
 msgstr "⭕ Nenhum certificado X509 válido foi encontrado"
 
-#: src/Config/ConfigItem.php:583
+#: src/Config/ConfigItem.php:823
 msgid "⚠️ OpenSSL is not available, GLPI cant validate your certificate"
 msgstr ""
 "⚠️ OpenSSL não está disponível, o GLPI não consegue validar seu certificado"
 
-#: src/Config/ConfigForm.php:159
-msgid "Successfully added new samlSSO configuration."
-msgstr "Nova configuração do samlSSO adicionada com sucesso."
-
-#: src/Config/ConfigForm.php:163
-msgid "Unable to add new samlSSO configuration, please review error logging"
-msgstr ""
-"Não foi possível adicionar uma nova configuração do samlSSO. Por favor, "
-"verifique o registro de erros."
-
-#: src/Config/ConfigForm.php:168
-msgid "Configuration invalid, please correct all ⭕ errors first"
-msgstr ""
-"Configuração inválida, por favor corrija todos os erros marcados com ⭕ "
-"primeiro"
-
-#: src/Config/ConfigForm.php:196 src/LoginFlow/LoginFlowForm.php:100
-msgid "Configuration updated successfully"
-msgstr "Configuração atualizada com sucesso"
-
-#: src/Config/ConfigForm.php:200 src/LoginFlow/LoginFlowForm.php:104
-msgid "Configuration update failed, check your update rights or error logging"
-msgstr ""
-"A atualização da configuração falhou. Verifique suas permissões de "
-"atualização ou o registro de erros."
-
-#: src/Config/ConfigForm.php:205 src/LoginFlow/LoginFlowForm.php:109
-msgid "Configuration invalid please correct all ⭕ errors first"
-msgstr "Configuração inválida. Corrija todos os erros ⭕ primeiro."
-
-#: src/Config/ConfigForm.php:225
-msgid "Configuration deleted successfully"
-msgstr "Configuração apagada com sucesso"
-
-#: src/Config/ConfigForm.php:229
-msgid "Not allowed or error deleting SAML configuration!"
-msgstr "Não é permitido ou ocorreu um erro ao excluir a configuração SAML!"
-
-#: src/Config/ConfigForm.php:248 src/LoginFlow/LoginFlowForm.php:128
-msgid "Invalid request, redirecting back"
-msgstr "Solicitação inválida, redirecionando de volta."
-
-#: src/Config/ConfigForm.php:357 src/LoginFlow/LoginFlowForm.php:176
-msgid "Email Address"
-msgstr "Endereço de email"
-
-#: src/Config/ConfigForm.php:358 src/LoginFlow/LoginFlowForm.php:177
-msgid "Transient"
-msgstr "Transitório"
-
-#: src/Config/ConfigForm.php:359 src/LoginFlow/LoginFlowForm.php:178
-msgid "Persistent"
-msgstr "Persistente"
-
-#: src/Config/ConfigForm.php:360 src/LoginFlow/LoginFlowForm.php:179
-msgid "PasswordProtectedTransport"
-msgstr "Transporte protegido por senha"
-
-#: src/Config/ConfigForm.php:362 src/LoginFlow/LoginFlowForm.php:181
-msgid "X509"
-msgstr "X509"
-
-#: src/Config/ConfigForm.php:363 src/LoginFlow/LoginFlowForm.php:182
-msgid "none"
-msgstr "nenhum"
-
-#: src/Config/ConfigForm.php:364 src/LoginFlow/LoginFlowForm.php:183
-msgid "Exact"
-msgstr "Exato"
-
-#: src/Config/ConfigForm.php:367 src/LoginFlow/LoginFlowForm.php:186
-msgid "Better"
-msgstr "Melhor"
-
-#: src/Config/ConfigEntity.php:344
-msgid ""
-"⚠️ SP private key does not seem to match provided SP certificates modulus."
-msgstr ""
-"⚠️ A chave privada do SP parece não corresponder ao módulo dos certificados "
-"SP fornecidos."
-
-#: src/Config/ConfigEntity.php:349
-msgid ""
-"⚠️ Will be defaulted to \"No\" because the provided SP certificate does not "
-"look valid!"
-msgstr ""
-"⚠️ Será definido como \"Não\" por padrão, pois o certificado SP fornecido "
-"parece não ser válido!"
-
-#: src/LoginFlow.php:162
-msgid "samlFlow"
-msgstr "Fluxo salm"
-
-#: src/LoginFlow.php:406
-msgid ""
-"Could not update the loginState and therefor stopped the loginFlow for:"
-msgstr ""
-"Não foi possível atualizar o estado de login e, portanto, o fluxo de login "
-"foi interrompido para:"
-
-#: src/LoginFlow.php:495
-msgid "⚠️ Are you sure?"
-msgstr "⚠️ Tem certeza?"
-
-#: src/LoginFlow.php:497
-msgid "Continue GLPI logout"
-msgstr "Continuar logoff no GLPI"
-
-#: src/LoginFlow.php:499
-msgid "Log out everywhere"
-msgstr "Sair de todas as seções"
-
-#: src/LoginFlow.php:549
-msgid "Login with external provider"
-msgstr "Login com provedor externo"
-
-#: src/LoginFlow.php:584
-msgid "⚠️ Sorry we are unable to log you in"
-msgstr "⚠️ Desculpe, não conseguimos efetuar o seu login"
-
-#: src/LoginFlow.php:589 src/LoginFlow.php:629
-msgid "Return to GLPI"
-msgstr "Voltar para o GLPI"
-
-#: src/LoginFlow.php:625
-msgid "⚠️ An error occurred"
-msgstr "⚠️ Um erro ocorreu"
-
-#: src/Config.php:123
+#: src/Config.php:125
 msgid "samlSSO"
 msgstr "samlSSO"
 
-#: src/Config.php:146 src/Exclude.php:86
+#: src/Config.php:149 src/Exclude.php:87
 msgid "Excluded paths"
 msgstr "Caminhos excluídos"
 
-#: src/Config.php:181
+#: src/Config.php:184
 msgid "Idp entity ID"
 msgstr "ID da entidade do IDP"
 
-#: src/LoginFlow/Acs.php:133
-msgid "Unable to fetch idp configuration with id:"
-msgstr ""
-"Não foi possível obter a configuração do provedor de identidade com o "
-"seguinte ID:"
+#: src/CronTask.php:66
+msgid "Clean old SAML sessions"
+msgstr "Limpar seções SAML antigas"
 
-#: src/LoginFlow/Acs.php:134
-msgid "Assert saml"
-msgstr "Afirmar saml"
+#: src/CronTask.php:67
+msgid "SAML sessions retention period (in days, 0 for infinite)"
+msgstr "Tempo de retenção das seções SAML (em dias, 0 para ininito)"
 
-#: src/LoginFlow/Acs.php:151 src/LoginFlow/Acs.php:165
-msgid "phpSaml::Settings->init"
-msgstr "phpSaml::Settings->init"
+#: src/CronTask.php:69
+msgid "Update GeoIP offline database"
+msgstr "Atualizar banco de dados GeoIP offline"
 
-#: src/LoginFlow/Acs.php:178
-msgid "Could not process samlResponse with Error:"
-msgstr ""
-"Não foi possível processar a resposta samlResponse com o seguinte erro:"
+#: src/LoginFlow/User.php:170 src/LoginFlow/User.php:175
+msgid "User with GlpiUserid: "
+msgstr "Usuário com GlpiUserid: "
 
-#: src/LoginFlow/Acs.php:179
-msgid "Saml::Response->init"
-msgstr "Saml::Response->init"
-
-#: src/LoginFlow/Acs.php:193
-msgid "LoginState"
-msgstr "Estado do login"
-
-#: src/LoginFlow/Acs.php:202
+#: src/LoginFlow/User.php:187
 msgid ""
-"The received idp response did not contain the required samlResponse POST "
-"body or idpId to authenticate the user, see: "
-"https://codeberg.org/QuinQuies/glpisaml/wiki/ACS.php for more information"
+"Your SSO login was successful but no GLPI profile was assigned to your "
+"account. Please contact your GLPI administrator to assign a profile to your "
+"account."
 msgstr ""
-"A resposta do provedor de identidade recebida não continha o corpo POST "
-"samlResponse ou o idpId necessários para autenticar o usuário. Consulte: "
-"https://codeberg.org/QuinQuies/glpisaml/wiki/ACS.php para obter mais "
-"informações."
+"Seu login SSO foi bem-sucedido, mas nenhum perfil GLPI foi atribuído à sua "
+"conta. Por favor, entre em contato com o administrador do GLPI para atribuir "
+"um perfil à sua conta."
 
-#: src/LoginFlow/Acs.php:203
-msgid "Acs assertion"
-msgstr "Afirmação de contas"
-
-#: src/LoginFlow/Acs.php:226
+#: src/LoginFlow/User.php:212
 msgid ""
-"It looks like this samlResponse has already been used to authenticate a different user.\n"
-"                                 Maybe an error occurred and you pressed F5 and accidently resend the samlResponse that is\n"
-"                                 already registered as processed. For security reasons we can not allow processed samlResponses\n"
-"                                 to be processed again. Please login again to generate a new samlResponse. Sorry for any inconvenience.\n"
-"                                 If the problem presists, then please contact your administrator.\n"
-"                                 See: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php for more information"
+"Your SSO login was successful but the identity provider configuration is "
+"invalid or disabled."
 msgstr ""
-"Parece que esta resposta SAML já foi usada para autenticar outro usuário. "
-"Talvez tenha ocorrido um erro e você pressionou F5, reenviando "
-"acidentalmente a resposta SAML que já está registrada como processada. Por "
-"motivos de segurança, não podemos permitir que respostas SAML processadas "
-"sejam processadas novamente. Faça login novamente para gerar uma nova "
-"resposta SAML. Pedimos desculpas por qualquer inconveniente. Se o problema "
-"persistir, entre em contato com o administrador. Consulte: "
-"https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php para obter mais "
-"informações."
+"Seu login SSO foi bem-sucedido, mas a configuração do provedor de identidade "
+"é inválida ou desabilitada."
 
-#: src/LoginFlow/Acs.php:246
+#: src/LoginFlow/User.php:221
 msgid ""
-"An error occured while trying to update the samlResponseId into the "
-"LoginState database. Review the saml log for more details"
+"Your SSO login was successful but there is no matching GLPI user account "
+"and\n"
+"                                                we failed to create one "
+"dynamically using Just In Time user creation. Please\n"
+"                                                request a GLPI administrator "
+"to review the logs and correct the problem or\n"
+"                                                request the administrator to "
+"create a GLPI user manually."
 msgstr ""
-"Ocorreu um erro ao tentar atualizar o samlResponseId no banco de dados "
-"LoginState. Consulte o log SAML para obter mais detalhes."
+"Seu login SSO foi bem-sucedido, mas não há uma conta de usuário GLPI "
+"correspondente e não conseguimos criar uma dinamicamente usando a criação de "
+"usuário Just In Time. Solicite a um administrador do GLPI que revise os "
+"registros e corrija o problema ou solicite que o administrador crie um "
+"usuário GLPI manualmente."
 
-#: src/LoginFlow/Acs.php:257
+#: src/LoginFlow/User.php:234
 msgid ""
-"GLPI did not expect an assertion from this Idp. The most likely reason is a race condition\n"
-"                                  causing an inconsistant loginState in the database or software bug. Please login again via the\n"
-"                                  GLPI-interface. Sorry for the inconvenience. See: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php\n"
-"                                  for more information"
+"Your SSO login was successful but no GLPI profile was assigned to your "
+"account and\n"
+"                                                    we failed to assign one "
+"dynamically using Just In Time user creation. Please\n"
+"                                                    request a GLPI "
+"administrator to review the logs and correct the problem or\n"
+"                                                    request the "
+"administrator to assign a GLPI profile manually."
 msgstr ""
-"GLPI não esperava uma asserção deste IdP. A razão mais provável é uma "
-"condição de corrida causando um estado de login inconsistente no banco de "
-"dados ou um bug de software. Por favor, faça login novamente através da "
-"interface GLPI. Pedimos desculpas pelo inconveniente. Veja: "
-"https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php para mais "
-"informações."
+"Seu login SSO foi bem-sucedido, mas não há uma conta de usuário GLPI "
+"correspondente e não conseguimos criar uma dinamicamente usando a criação de "
+"usuário Just In Time (JIT). Solicite a um administrador do GLPI que revise "
+"os logs e corrija o problema ou solicite que o administrador crie um usuário "
+"GLPI manualmente."
 
-#: src/LoginFlow/Acs.php:261
-msgid "samlResponse assertion"
-msgstr "Afirmação samlResponse"
-
-#: src/LoginFlow/Acs.php:274
+#: src/LoginFlow/User.php:242
 msgid ""
-"An error occured while trying to update the login phase to LoginState::PHASE_SAML_AUTH  into the LoginState database.\n"
-"                                  Review the saml log for more details"
+"Critical error: samlSSO was unable to fetch newly created user from the "
+"database!"
 msgstr ""
-"Ocorreu um erro ao tentar atualizar a fase de login para LoginState::PHASE_SAML_AUTH no banco de dados LoginState. \n"
-"Consulte o log SAML para obter mais detalhes."
+"Erro crítico: o samlSSO não conseguiu recuperar o usuário recém-criado do "
+"banco de dados!"
 
-#: src/LoginFlow/Acs.php:282
+#: src/LoginFlow/User.php:264
+msgid "JIT was called with params:"
+msgstr "O JIT foi chamado com os seguintes parâmetros:"
+
+#: src/LoginFlow/User.php:333
+msgid "Created by phpSaml Just-In-Time user creation on:"
+msgstr "Criado por phpSaml Just-In-Time (JIT) usuário criado em:"
+
+#: src/LoginFlow/User.php:486
+msgid "JIT group already assigned:"
+msgstr "Grupo JIT já atribuído:"
+
+#: src/LoginFlow/User.php:497
+msgid "JIT failed to assign groupID:"
+msgstr "O JIT não conseguiu atribuir o groupID:"
+
+#: src/LoginFlow/User.php:502
+msgid "JIT assigned groupID:"
+msgstr "ID de grupo atribuído pelo JIT:"
+
+#: src/LoginFlow/User.php:509
+msgid "JIT found no groupId to add.\n"
+msgstr "O JIT não encontrou nenhum grupoId para adicionar.\n"
+
+#: src/LoginFlow/User.php:533
+msgid "JIT found entity for profile assignment:"
+msgstr "O sistema JIT encontrou a entidade para atribuição de perfil:"
+
+#: src/LoginFlow/User.php:535
 msgid ""
-"Validation of the samlResponse document failed. Review the saml log for more"
-" details"
+"JIT didnt find a profile for entity assignment. Profile asignment might not "
+"work.\n"
 msgstr ""
-"A validação do documento samlResponse falhou. Consulte o log saml para obter"
-" mais detalhes."
+"O JIT não encontrou um perfil para atribuição de entidade. A atribuição de "
+"perfil pode não funcionar.\n"
 
-#: src/LoginFlow/LoginFlowItem.php:110
-msgid "⭕ IDP ID must be a positive numeric value!"
-msgstr "⭕ O ID do IDP deve ser um valor numérico positivo!"
+#: src/LoginFlow/User.php:541
+msgid "JIT found to be assigned profile(s) to be recursive.\n"
+msgstr "O JIT foi considerado como tendo atribuído perfil(s) recursivo(s).\n"
 
-#: src/LoginFlow/LoginFlowItem.php:113
-msgid "What IDP ID should be enforced?"
-msgstr "Qual ID do provedor de identidade (IdP) deve ser imposto?"
+#: src/LoginFlow/User.php:543
+msgid "JIT didnt find to be assigned profile(s) to be recursive.\n"
+msgstr "O JIT não encontrou perfis atribuídos que fossem recursivos.\n"
 
-#: src/LoginFlow/LoginFlowItem.php:114
-msgid "ENFORCED IDP ID"
-msgstr "FORÇAR IDP ID"
+#: src/LoginFlow/User.php:560
+msgid "JIT profile already assigned with config:"
+msgstr "Perfil JIT já atribuído com configuração:"
 
-#: src/LoginFlow/LoginFlowItem.php:129
-msgid "Debug enabled?"
-msgstr "Habilitar debug?"
-
-#: src/LoginFlow/LoginFlowItem.php:140
-msgid ""
-"Should SAML SSO be enforced. This option can be bypassed by the bypass var "
-"and value"
+#: src/LoginFlow/User.php:566
+msgid "JIT was not able to assign profile with config:"
 msgstr ""
-"O SSO SAML deve ser forçado? Esta opção pode ser ignorada pela variável e "
-"valor de bypass."
+"O JIT não conseguiu atribuir um perfil com as configurações existentes:"
 
-#: src/LoginFlow/LoginFlowItem.php:141
-msgid "ENFORCE SSO"
-msgstr "FORÇAR SSO"
-
-#: src/LoginFlow/LoginFlowItem.php:151
-msgid "Try to match domain in username for IDP selection"
+#: src/LoginFlow/User.php:572
+msgid "JIT remove all default profiles from newly created user:\n"
 msgstr ""
-"Tente encontrar uma correspondência entre o domínio e o nome de usuário para"
-" a seleção do IdP."
+"JIT removeu todos os perfis existentes e padrão do usuário recém-criado:\n"
 
-#: src/LoginFlow/LoginFlowItem.php:152
-msgid "ENABLE DOMAIN BASED SSO"
-msgstr "HABILITAR DOMINIO BASEADO NO SSO"
+#: src/LoginFlow/User.php:580
+msgid "Done\n"
+msgstr "Concluído\n"
 
-#: src/LoginFlow/LoginFlowItem.php:162
-msgid "Allow the ?idpId=[val] URI to pre select IDP from URLs"
-msgstr "Permitir que o IDPID=[val] URI pré-selecione o IDP a partir de URLs"
+#: src/LoginFlow/User.php:582
+msgid "failed\n"
+msgstr "falhou\n"
 
-#: src/LoginFlow/LoginFlowItem.php:163
-msgid "Enable getter login"
-msgstr "Habilitar login do getter"
+#: src/LoginFlow/User.php:584
+msgid "JIT assigned profile with config:"
+msgstr "Perfil atribuído pelas configurações do JIT:"
 
-#: src/LoginFlow/LoginFlowItem.php:173
-msgid ""
-"Hide the default GLPI login options. This option can be bypassed using the "
-"bypass var and value."
-msgstr ""
-"Ocultar as opções de login padrão do GLPI. Essa opção pode ser ignorada "
-"usando a variável e o valor de bypass."
+#: src/LoginFlow/User.php:617
+msgid "JIT found default groupID:"
+msgstr "JIT encontrou o groupID padrão:"
 
-#: src/LoginFlow/LoginFlowItem.php:174
-msgid "HIDE GLPI LOGIN"
-msgstr "OCULTAR GLPI LOGIN"
+#: src/LoginFlow/User.php:619
+msgid "Jit didnt find a default GroupID to assign, skipping\n"
+msgstr "Jit não encontrou um GroupID padrão para atribuir, ignorando\n"
 
-#: src/LoginFlow/LoginFlowItem.php:184
-msgid ""
-"Hides Saml Buttons. This option cannot be used together with the Hide GLPI "
-"login."
-msgstr ""
-"Ocultar os botões Saml. Esta opção não pode ser usada em conjunto com a "
-"opção Ocultar login GLPI."
+#: src/LoginFlow/User.php:624
+msgid "JIT found default entityID:"
+msgstr "JIT encontrou a entityID padrão:"
 
-#: src/LoginFlow/LoginFlowItem.php:185
-msgid "Hide Saml Buttons"
-msgstr "Ocultar botões Saml"
+#: src/LoginFlow/User.php:626
+msgid "Jit didnt find a default EntityId to assign, skipping\n"
+msgstr "Jit não encontrou uma EntityId padrão para atribuir, ignorando\n"
 
-#: src/LoginFlow/LoginFlowItem.php:195
-msgid "Hide the GLPI password field. To be used with Enable Domain Login."
-msgstr ""
-"Ocultar o campo de senha do GLPI. Para ser usado com a opção Ativar login de"
-" domínio."
+#: src/LoginFlow/User.php:631
+msgid "JIT found default profileID:"
+msgstr "JIT encontrou o profileID padrão:"
 
-#: src/LoginFlow/LoginFlowItem.php:196
-msgid "HIDE PASSWORD FIELD"
-msgstr "OCULTAR CAMPO DE SENHA"
+#: src/LoginFlow/User.php:633
+msgid "Jit didnt find a default ProfileId to assign, skipping\n"
+msgstr "Jit não encontrou um ProfileId padrão para atribuir, ignorando\n"
 
-#: src/LoginFlow/LoginFlowItem.php:206
-msgid "Forces samlSSO to (re)apply the rules on each succesfull auth."
-msgstr ""
-"Obriga o samlSSO a (re)aplicar as regras em cada autenticação bem-sucedida."
+#: src/LoginFlow/User.php:638
+msgid "JIT found timezone:"
+msgstr "JIT encontrou o fuso horário:"
 
-#: src/LoginFlow/LoginFlowItem.php:207
-msgid "APPLY RULES ON AUTH"
-msgstr "APLICAR REGRAS DE AUTORIZAÇÃO"
+#: src/LoginFlow/User.php:643
+msgid "JIT found is_active:"
+msgstr "JIT encontrou is_active:"
+
+#: src/LoginFlow/User.php:648
+msgid "JIT found locations_id:"
+msgstr "JIT encontrou o locations_id:"
+
+#: src/LoginFlow/User.php:653
+msgid "JIT found usercategories_id:"
+msgstr "JIT encontrou usercategories_id:"
+
+#: src/LoginFlow/User.php:658
+msgid "JIT found usertitles_id:"
+msgstr "JIT encontrou o usertitles_id:"
+
+#: src/LoginFlow/User.php:663
+msgid "JIT found language:"
+msgstr "JIT encontrou o idioma:"
+
+#: src/LoginFlow/User.php:668
+msgid "Jit updated user defaults\n"
+msgstr "Jit atualizou as configurações padrão do usuário\n"
+
+#: src/LoginFlow/User.php:670
+msgid "Jit didnt update user defaults\n"
+msgstr "Jit não atualizou as configurações padrão do usuário\n"
 
 #: src/LoginFlow/Meta.php:76
-msgid "Error fetching spMetedata."
-msgstr "Erro ao obter spMetadado."
+msgid "Error fetching spMetadata."
+msgstr "Erro ao obter spMetadata."
 
 #: src/LoginFlow/Meta.php:81
 msgid "Invalid id or metadata not exposed."
@@ -877,252 +1174,407 @@ msgstr "ID do metadado inválido ou não exposto."
 msgid "Error fetching config."
 msgstr "Erro ao obter a configuração."
 
-#: src/LoginFlow/User.php:165 src/LoginFlow/User.php:173
-msgid "User with GlpiUserid: "
-msgstr "Usuário com GlpiUserid:"
+#: src/LoginFlow/Acs.php:140
+msgid "Unable to fetch idp configuration with id:"
+msgstr ""
+"Não foi possível obter a configuração do provedor de identidade com o "
+"seguinte ID:"
 
-#: src/LoginFlow/User.php:189
+#: src/LoginFlow/Acs.php:141
+msgid "Samlsso->acs->init->FetchConfig"
+msgstr "Samlsso->acs->init->FetchConfig"
+
+#: src/LoginFlow/Acs.php:156
+#, php-format
 msgid ""
-"Your SSO login was successful but we where not able to fetch\n"
-"                                            the loginState from the database and could not continue to log\n"
-"                                            you into GLPI."
+"The received idp response did not contain the required samlResponse POST "
+"body or idpId to authenticate the user, see: %s for more information"
 msgstr ""
-"Seu login SSO foi bem-sucedido, mas não conseguimos obter o loginState \n"
-"do banco de dados e não pudemos continuar com o seu login no GLPI."
+"A resposta do provedor de identidade recebida não continha o corpo POST "
+"samlResponse ou o idpId necessários para autenticar o usuário. Consulte: %s "
+"para obter mais informações"
 
-#: src/LoginFlow/User.php:200
+#: src/LoginFlow/Acs.php:157
+msgid "Samlsso->acs->init->NoSamlResponse"
+msgstr "Samlsso->acs->init->NoSamlResponse"
+
+#: src/LoginFlow/Acs.php:179
+msgid "Samlsso->acs->init->phpsaml->Utils->setProxyVars"
+msgstr "Samlsso->acs->init->phpsaml->Utils->setProxyVars"
+
+#: src/LoginFlow/Acs.php:198
 msgid ""
-"Your SSO login was successful but there is no matching GLPI user account and\n"
-"                                                we failed to create one dynamically using Just In Time user creation. Please\n"
-"                                                request a GLPI administrator to review the logs and correct the problem or\n"
-"                                                request the administrator to create a GLPI user manually."
+"PHP-SAML could not initialize the settings object using the configEntity."
 msgstr ""
-"Seu login SSO foi bem-sucedido, mas não há uma conta de usuário GLPI "
-"correspondente e não conseguimos criar uma dinamicamente usando a criação de"
-" usuário Just In Time. Solicite a um administrador do GLPI que revise os "
-"registros e corrija o problema ou solicite que o administrador crie um "
-"usuário GLPI manualmente."
+"O PHP-SAML não conseguiu inicializar o objeto de configurações usando a "
+"entidade de configuração."
 
-#: src/LoginFlow/User.php:222
+#: src/LoginFlow/Acs.php:199
+msgid "Samlsso->acs->init->phpsaml->initializeSettings"
+msgstr "Samlsso->acs->init->phpsaml->initializeSettings"
+
+#: src/LoginFlow/Acs.php:207
+msgid "PHP-SAML library could not process samlResponse and reported the error:"
+msgstr ""
+"A biblioteca PHP-SAML não conseguiu processar o samlResponse e reportou o "
+"erro:"
+
+#: src/LoginFlow/Acs.php:208
+msgid "Samlsso->acs->init->phpsaml->initializeResponse"
+msgstr "Samlsso->acs->init->phpsaml->initializeResponse"
+
+#: src/LoginFlow/Acs.php:227
+#, php-format
 msgid ""
-"Critical error: samlSSO was unable to fetch newly created user from the "
-"database!"
+"Could not fetch loginState from database with error: <br><br>%s<br><br>See: "
+"%s for more information."
 msgstr ""
-"Erro crítico: o samlSSO não conseguiu recuperar o usuário recém-criado do "
-"banco de dados!"
+"Não foi possível obter o estado de login do banco de dados com erro: "
+"<br><br>%s<br><br> Consulte: %s para mais informações."
 
-#: src/LoginFlow/User.php:239
-msgid "JIT was called with params:"
-msgstr "O JIT foi chamado com os seguintes parâmetros:"
+#: src/LoginFlow/Acs.php:228
+msgid "Samlsso->acs->init->LoginState::construct"
+msgstr "Samlsso->acs->init->LoginState::construct"
 
-#: src/LoginFlow/User.php:250
-msgid "JIT failed to assign groupID:"
-msgstr "O JIT não conseguiu atribuir o groupID:"
-
-#: src/LoginFlow/User.php:252
-msgid "JIT assigned groupID:"
-msgstr "ID de grupo atribuído pelo JIT:"
-
-#: src/LoginFlow/User.php:255
-msgid "JIT found no groupId to add.\n"
-msgstr "O JIT não encontrou nenhum grupoId para adicionar.\n"
-
-#: src/LoginFlow/User.php:269
-msgid "JIT found entity for profile assignment:"
-msgstr "O sistema JIT encontrou a entidade para atribuição de perfil:"
-
-#: src/LoginFlow/User.php:271
+#: src/LoginFlow/Acs.php:251
 msgid ""
-"JIT didnt find a profile for entity assignment. Profile asignment might not "
-"work.\n"
+"Validation of the samlResponse document failed. Review the saml log for more "
+"details"
 msgstr ""
-"O JIT não encontrou um perfil para atribuição de entidade. A atribuição de "
-"perfil pode não funcionar.\n"
+"A validação do documento samlResponse falhou. Consulte o log saml para obter "
+"mais detalhes"
 
-#: src/LoginFlow/User.php:277
-msgid "JIT found to be assigned profile(s) to be recursive.\n"
-msgstr "O JIT foi considerado como tendo atribuído perfil(s) recursivo(s).\n"
+#: src/LoginFlow/Acs.php:252 src/LoginFlow/Acs.php:259
+msgid "Samlsso->acs->assertSaml->SamlResponse::isValid"
+msgstr "Samlsso->acs->assertSaml->SamlResponse::isValid"
 
-#: src/LoginFlow/User.php:279
-msgid "JIT didnt find to be assigned profile(s) to be recursive.\n"
-msgstr "O JIT não encontrou perfis atribuídos que fossem recursivos.\n"
-
-#: src/LoginFlow/User.php:283
-msgid "JIT remove all existing and default profiles from newly created user:\n"
-msgstr ""
-"JIT remove todos os perfis existentes e padrão do usuário recém-criado:\n"
-
-#: src/LoginFlow/User.php:289
-msgid "Done\n"
-msgstr "Feito\n"
-
-#: src/LoginFlow/User.php:291
-msgid "failed\n"
-msgstr "falhou\n"
-
-#: src/LoginFlow/User.php:298
-msgid "JIT was not able to assign profile with config:"
-msgstr ""
-"O JIT não conseguiu atribuir um perfil com as configurações existentes:"
-
-#: src/LoginFlow/User.php:300
-msgid "JIT assigned profile with config:"
-msgstr "Perfil atribuído pelas configurações do JIT:"
-
-#: src/LoginFlow/User.php:313
-msgid "JIT found default groupID:"
-msgstr "JIT encontrou um grupoID padrão"
-
-#: src/LoginFlow/User.php:315
-msgid "Jit didnt find a default GroupID to assign, skipping\n"
-msgstr "Jit não encontrou um GroupID padrão para atribuir, ignorando\n"
-
-#: src/LoginFlow/User.php:320
-msgid "JIT found default entityID:"
-msgstr "JIT encontrou entityID padrão:"
-
-#: src/LoginFlow/User.php:322
-msgid "Jit didnt find a default EntityId to assign, skipping\n"
-msgstr "Jit não encontrou uma EntityId padrão para atribuir, ignorando\n"
-
-#: src/LoginFlow/User.php:327
-msgid "JIT found default profileID:"
-msgstr "JIT encontrou um profileID padrão:"
-
-#: src/LoginFlow/User.php:329
-msgid "Jit didnt find a default ProfileId to assign, skipping\n"
-msgstr "Jit não encontrou um ProfileId padrão para atribuir, ignorando\n"
-
-#: src/LoginFlow/User.php:334
-msgid "Jit updated user defaults\n"
-msgstr "Jit atualizou as configurações padrão do usuário\n"
-
-#: src/LoginFlow/User.php:336
-msgid "Jit didnt update user defaults\n"
-msgstr "Jit não atualizou as configurações padrão do usuário\n"
-
-#: src/LoginFlow/User.php:380
-msgid "NameId attribute is missing in samlResponse"
-msgstr "O atributo NameId foi perdido em samlResponse"
-
-#: src/LoginFlow/User.php:389
+#: src/LoginFlow/Acs.php:258
 msgid ""
-"Detected a default guest user in samlResponse, this is not supported<br>\n"
-"                                      by glpiSAML. Please create a dedicated account for this user owned by your\n"
-"                                      tenant/identity provider.<br>\n"
-"                                      Also see: https://learn.microsoft.com/en-us/azure/active-directory/develop/saml-claims-customization"
+"Validation of the samlResponse document failed with a critical error. Review "
+"the saml log for more details"
 msgstr ""
-"Foi detectado um usuário convidado padrão na resposta SAML. Isso não é compatível com o glpiSAML. \n"
-"Crie uma conta dedicada para este usuário pertencente ao seu locatário/provedor de identidade. \n"
-"Consulte também: https://learn.microsoft.com/en-us/azure/active-directory/develop/saml-claims-customization"
+"A validação do documento samlResponse falhou. Consulte o log saml para obter "
+"mais detalhes"
 
-#: src/LoginFlow/User.php:422
+#: src/LoginFlow/Acs.php:279
+#, php-format
 msgid ""
-"SamlResponse should have at least 1 valid email address for GLPI  to find\n"
-"                                          the corresponding GLPI user or create it (with JIT enabled). For this purpose make\n"
-"                                          sure either the IDP provided NameId property is populated with the email address format,\n"
-"                                          or configure the IDP to add the users email address in the samlResponse claims using\n"
-"                                          the designated schema property key:"
+"It looks like this samlResponse has already been used to authenticate a "
+"different user.\n"
+"                    Maybe an error occurred and you pressed F5 and "
+"accidently resend the samlResponse that is\n"
+"                    already registered as processed. For security reasons we "
+"can not allow processed samlResponses\n"
+"                    to be processed again. Please login again to generate a "
+"new samlResponse. Sorry for any inconvenience.\n"
+"                    If the problem presists, then please contact your "
+"administrator.\n"
+"                    See: %s for more information"
 msgstr ""
-"A resposta SamlResponse deve conter pelo menos 1 endereço de e-mail válido "
-"para que o GLPI encontre o usuário GLPI correspondente ou o crie (com o JIT "
-"ativado). Para isso, certifique-se de que a propriedade NameId fornecida "
-"pelo IdP esteja preenchida com o formato de endereço de e-mail ou configure "
-"o IdP para adicionar o endereço de e-mail do usuário às declarações "
-"SamlResponse usando a chave de propriedade de esquema designada."
+"Parece que esta resposta SAML já foi usada para autenticar outro usuário. "
+"Talvez tenha ocorrido um erro e você pressionou F5, reenviando "
+"acidentalmente a resposta SAML que já está registrada como processada. Por "
+"motivos de segurança, não podemos permitir que respostas SAML processadas "
+"sejam processadas novamente. Faça login novamente para gerar uma nova "
+"resposta SAML. Pedimos desculpas por qualquer inconveniente. Se o problema "
+"persistir, entre em contato com o administrador. Consulte: %s para obter "
+"mais informações"
 
-#: src/LoginFlow/User.php:446
+#: src/LoginFlow/Acs.php:285
+msgid "Samlsso->acs->assertSaml->LoginState::checkResponseIdUnique"
+msgstr "Samlsso->acs->assertSaml->LoginState::checkResponseIdUnique"
+
+#: src/LoginFlow/Acs.php:306
 msgid ""
-"Provided firstname or givenname exceeded 255 characters. This claim should "
-"not be longer than 255 characters"
+"An error occured while trying to update the samlResponseId into the "
+"LoginState database. Review the saml log for more details"
 msgstr ""
-"O nome fornecido excedeu 255 caracteres. Esta declaração não deve ter mais "
-"de 255 caracteres."
+"Ocorreu um erro ao tentar atualizar o samlResponseId no banco de dados "
+"LoginState. Consulte o log SAML para obter mais detalhes"
 
-#: src/LoginFlow/User.php:457
+#: src/LoginFlow/Acs.php:307
+msgid "Samlsso->acs->assertSaml->LoginState::setSamlResponseId"
+msgstr "Samlsso->acs->assertSaml->LoginState::setSamlResponseId"
+
+#: src/LoginFlow/Acs.php:320
+#, php-format
 msgid ""
-"Provided surname claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
+"GLPI did not expect an assertion from this Idp. The most likely reason is a "
+"race condition\n"
+"                    causing an inconsistant loginState in the database or "
+"software bug. Please login again via the\n"
+"                    GLPI-interface. Sorry for the inconvenience. See: %s\n"
+"                    for more information"
 msgstr ""
-"O sobrenome fornecido excedeu 255 caracteres. Este sobrenome não deve ter "
-"mais de 255 caracteres."
+"O GLPI não esperava uma asserção deste IdP. A razão mais provável é uma "
+"condição de corrida causando um estado de login inconsistente no banco de "
+"dados ou um bug de software. Por favor, faça login novamente através da "
+"interface GLPI. Pedimos desculpas pelo inconveniente. Consulte: %s para mais "
+"informações"
 
-#: src/LoginFlow/User.php:470
+#: src/LoginFlow/Acs.php:324
+msgid "Samlsso->acs->assertSaml->PhaseMismatched"
+msgstr "Samlsso->acs->assertSaml->PhaseMismatched"
+
+#: src/LoginFlow/Acs.php:338
 msgid ""
-"Provided job title claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
+"An error occured while trying to update the login phase to "
+"LoginState::PHASE_SAML_AUTH  into the LoginState database.\n"
+"                                  Review the saml log for more details"
 msgstr ""
-"O título do cargo fornecido excedeu 255 caracteres. Este título não deve ter"
-" mais de 255 caracteres."
+"Ocorreu um erro ao tentar atualizar a fase de login para "
+"LoginState::PHASE_SAML_AUTH no banco de dados LoginState. \n"
+"Consulte o log SAML para obter mais detalhes"
 
-#: src/LoginFlow/User.php:483
-msgid ""
-"Provided mobile phone number claim exceeded 255 characters. This claim "
-"should not be longer than 255 characters"
-msgstr ""
-"O número de celular fornecido excedeu 255 caracteres. Este formulário não "
-"deve ter mais de 255 caracteres."
+#: src/LoginFlow/Acs.php:339
+msgid "LoginState"
+msgstr "Estado do login"
 
-#: src/LoginFlow/User.php:496
-msgid ""
-"Provided telephone phone number claim exceeded 255 characters. This claim "
-"should not be longer than 255 characters"
-msgstr ""
-"O número de telefone fornecido excedeu 255 caracteres. Este número não deve "
-"ter mais de 255 caracteres."
-
-#: src/LoginFlow/User.php:509
-msgid ""
-"Provided country claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
-msgstr ""
-"A declaração do país excedeu 255 caracteres. Esta declaração não deve ter "
-"mais de 255 caracteres."
-
-#: src/LoginFlow/User.php:522
-msgid ""
-"Provided city claim exceeded 255 characters. This claim should not be longer"
-" than 255 characters"
-msgstr ""
-"A declaração da cidade excedeu 255 caracteres. Esta declaração não deve ter "
-"mais de 255 caracteres."
-
-#: src/LoginFlow/User.php:535
-msgid ""
-"Provided street address claim exceeded 255 characters. This claim should not"
-" be longer than 255 characters"
-msgstr ""
-"O endereço fornecido excedeu 255 caracteres. Este endereço não deve ter mais"
-" de 255 caracteres."
-
-#: src/LoginFlow/User.php:546
-msgid "Created by phpSaml Just-In-Time user creation on:"
-msgstr "Criado por phpSaml Just-In-Time (JIT) usuário criado em:"
-
-#: src/LoginFlow/LoginFlowForm.php:69
+#: src/LoginFlow/LoginFlowForm.php:71
 msgid "Identity providers"
 msgstr "Provedores de identidade"
 
-#: src/Exclude.php:124
+#: src/LoginFlow/LoginFlowForm.php:114
+msgid "Configuration invalid please correct all ⭕ errors first"
+msgstr "Configuração inválida. Corrija todos os erros ⭕ primeiro."
+
+#: src/LoginFlow/LoginFlowItem.php:120
+msgid "⭕ IDP ID must be a positive numeric value!"
+msgstr "⭕ O ID do IDP deve ser um valor numérico positivo!"
+
+#: src/LoginFlow/LoginFlowItem.php:124
+msgid "What IDP ID should be enforced?"
+msgstr "Qual ID do provedor de identidade (IdP) deve ser imposto?"
+
+#: src/LoginFlow/LoginFlowItem.php:125
+msgid "ENFORCED IDP ID"
+msgstr "ENFORÇAR IDP ID"
+
+#: src/LoginFlow/LoginFlowItem.php:144
+msgid "Debug enabled?"
+msgstr "Habilitar debug?"
+
+#: src/LoginFlow/LoginFlowItem.php:161
+msgid ""
+"Should SAML SSO be enforced. This option can be bypassed by the bypass var "
+"and value"
+msgstr ""
+"O SSO SAML deve ser forçado? Esta opção pode ser ignorada pela variável e "
+"valor de bypass"
+
+#: src/LoginFlow/LoginFlowItem.php:162
+msgid "ENFORCE SSO"
+msgstr "ENFORÇAR SSO"
+
+#: src/LoginFlow/LoginFlowItem.php:178
+msgid "Try to match domain in username for IDP selection"
+msgstr ""
+"Tente encontrar uma correspondência entre o domínio e o nome de usuário para "
+"a seleção do IdP"
+
+#: src/LoginFlow/LoginFlowItem.php:179
+msgid "ENABLE DOMAIN BASED SSO"
+msgstr "HABILITAR DOMINIO BASEADO NO SSO"
+
+#: src/LoginFlow/LoginFlowItem.php:195
+msgid "Allow the ?idpId=[val] URI to pre select IDP from URLs"
+msgstr "Permitir que o IDPID=[val] URI pré-selecione o IDP a partir de URLs"
+
+#: src/LoginFlow/LoginFlowItem.php:196
+msgid "Enable getter login"
+msgstr "Habilitar login do getter"
+
+#: src/LoginFlow/LoginFlowItem.php:212
+msgid ""
+"Hide the default GLPI login options. This option can be bypassed using the "
+"bypass var and value."
+msgstr ""
+"Ocultar as opções de login padrão do GLPI. Essa opção pode ser ignorada "
+"usando a variável e o valor de bypass."
+
+#: src/LoginFlow/LoginFlowItem.php:213
+msgid "HIDE GLPI LOGIN"
+msgstr "OCULTAR LOGIN DO GLPI"
+
+#: src/LoginFlow/LoginFlowItem.php:229
+msgid ""
+"Hides Saml Buttons. This option cannot be used together with the Hide GLPI "
+"login."
+msgstr ""
+"Ocultar os botões Saml. Esta opção não pode ser usada em conjunto com a "
+"opção Ocultar login GLPI."
+
+#: src/LoginFlow/LoginFlowItem.php:230
+msgid "Hide Saml Buttons"
+msgstr "Ocultar botões Saml"
+
+#: src/LoginFlow/LoginFlowItem.php:246
+msgid "Hide the GLPI password field. To be used with Enable Domain Login."
+msgstr ""
+"Ocultar o campo de senha do GLPI. Para ser usado com a opção Ativar login de "
+"domínio."
+
+#: src/LoginFlow/LoginFlowItem.php:247
+msgid "HIDE PASSWORD FIELD"
+msgstr "OCULTAR CAMPO DE SENHA"
+
+#: src/LoginFlow/LoginFlowItem.php:263
+msgid "Forces samlSSO to (re)apply the rules on each succesfull auth."
+msgstr ""
+"Obriga o samlSSO a (re)aplicar as regras em cada autenticação bem-sucedida."
+
+#: src/LoginFlow/LoginFlowItem.php:264
+msgid "APPLY RULES ON AUTH"
+msgstr "APLICAR REGRAS DE AUTORIZAÇÃO"
+
+#: src/Exclude.php:126
 msgid "samlSSO Excludes"
 msgstr "Exclusões samlSSO"
 
-#: src/Exclude.php:146
+#: src/Exclude.php:149
 msgid "Agent contains"
 msgstr "Agente contém"
 
-#: src/Exclude.php:152
+#: src/Exclude.php:155
 msgid "Bypass SAML auth"
-msgstr "Bypassar a autenticação SAML"
+msgstr "Bypass da autenticação SAML"
 
-#: src/Exclude.php:157
+#: src/Exclude.php:160
 msgid "Url contains path or file"
 msgstr "Url contém caminho ou arquivo"
 
-#: src/Exclude.php:179
+#: src/Exclude.php:182
 msgid "Client Agent performing the call"
 msgstr "Agente do cliente realizando a chamada"
 
-#: src/Exclude.php:188
+#: src/Exclude.php:191
 msgid "To be excluded path"
 msgstr "Caminho a ser excluído"
+
+#: src/RuleSaml.php:86
+msgid "JIT rules"
+msgstr "Regras JIT"
+
+#: src/RuleSaml.php:153
+#, php-format
+msgid "SAML Claim: %s"
+msgstr "Reivindicação SAML: %s"
+
+#~ msgid "⚠️ Are you sure?"
+#~ msgstr "⚠️ Tem certeza?"
+
+#~ msgid "Assert saml"
+#~ msgstr "Afirmar saml"
+
+#~ msgid "phpSaml::Settings->init"
+#~ msgstr "phpSaml::Settings->init"
+
+#~ msgid "Saml::Response->init"
+#~ msgstr "Saml::Response->init"
+
+#~ msgid "Acs assertion"
+#~ msgstr "Afirmação de contas"
+
+#~ msgid "samlResponse assertion"
+#~ msgstr "Afirmação samlResponse"
+
+#~ msgid ""
+#~ "Your SSO login was successful but we where not able to fetch\n"
+#~ "                                            the loginState from the "
+#~ "database and could not continue to log\n"
+#~ "                                            you into GLPI."
+#~ msgstr ""
+#~ "Seu login SSO foi bem-sucedido, mas não conseguimos obter o loginState \n"
+#~ "do banco de dados e não pudemos continuar com o seu login no GLPI."
+
+#~ msgid ""
+#~ "Detected a default guest user in samlResponse, this is not supported<br>\n"
+#~ "                                      by glpiSAML. Please create a "
+#~ "dedicated account for this user owned by your\n"
+#~ "                                      tenant/identity provider.<br>\n"
+#~ "                                      Also see: https://"
+#~ "learn.microsoft.com/en-us/azure/active-directory/develop/saml-claims-"
+#~ "customization"
+#~ msgstr ""
+#~ "Foi detectado um usuário convidado padrão na resposta SAML. Isso não é "
+#~ "compatível com o glpiSAML. \n"
+#~ "Crie uma conta dedicada para este usuário pertencente ao seu locatário/"
+#~ "provedor de identidade. \n"
+#~ "Consulte também: https://learn.microsoft.com/en-us/azure/active-directory/"
+#~ "develop/saml-claims-customization"
+
+#~ msgid ""
+#~ "SamlResponse should have at least 1 valid email address for GLPI  to "
+#~ "find\n"
+#~ "                                          the corresponding GLPI user or "
+#~ "create it (with JIT enabled). For this purpose make\n"
+#~ "                                          sure either the IDP provided "
+#~ "NameId property is populated with the email address format,\n"
+#~ "                                          or configure the IDP to add the "
+#~ "users email address in the samlResponse claims using\n"
+#~ "                                          the designated schema property "
+#~ "key:"
+#~ msgstr ""
+#~ "A resposta SamlResponse deve conter pelo menos 1 endereço de e-mail "
+#~ "válido para que o GLPI encontre o usuário GLPI correspondente ou o crie "
+#~ "(com o JIT ativado). Para isso, certifique-se de que a propriedade NameId "
+#~ "fornecida pelo IdP esteja preenchida com o formato de endereço de e-mail "
+#~ "ou configure o IdP para adicionar o endereço de e-mail do usuário às "
+#~ "declarações SamlResponse usando a chave de propriedade de esquema "
+#~ "designada."
+
+#~ msgid ""
+#~ "Provided firstname or givenname exceeded 255 characters. This claim "
+#~ "should not be longer than 255 characters"
+#~ msgstr ""
+#~ "O nome fornecido excedeu 255 caracteres. Esta declaração não deve ter "
+#~ "mais de 255 caracteres."
+
+#~ msgid ""
+#~ "Provided surname claim exceeded 255 characters. This claim should not be "
+#~ "longer than 255 characters"
+#~ msgstr ""
+#~ "O sobrenome fornecido excedeu 255 caracteres. Este sobrenome não deve ter "
+#~ "mais de 255 caracteres."
+
+#~ msgid ""
+#~ "Provided job title claim exceeded 255 characters. This claim should not "
+#~ "be longer than 255 characters"
+#~ msgstr ""
+#~ "O título do cargo fornecido excedeu 255 caracteres. Este título não deve "
+#~ "ter mais de 255 caracteres."
+
+#~ msgid ""
+#~ "Provided mobile phone number claim exceeded 255 characters. This claim "
+#~ "should not be longer than 255 characters"
+#~ msgstr ""
+#~ "O número de celular fornecido excedeu 255 caracteres. Este formulário não "
+#~ "deve ter mais de 255 caracteres."
+
+#~ msgid ""
+#~ "Provided telephone phone number claim exceeded 255 characters. This claim "
+#~ "should not be longer than 255 characters"
+#~ msgstr ""
+#~ "O número de telefone fornecido excedeu 255 caracteres. Este número não "
+#~ "deve ter mais de 255 caracteres."
+
+#~ msgid ""
+#~ "Provided country claim exceeded 255 characters. This claim should not be "
+#~ "longer than 255 characters"
+#~ msgstr ""
+#~ "A declaração do país excedeu 255 caracteres. Esta declaração não deve ter "
+#~ "mais de 255 caracteres."
+
+#~ msgid ""
+#~ "Provided city claim exceeded 255 characters. This claim should not be "
+#~ "longer than 255 characters"
+#~ msgstr ""
+#~ "A declaração da cidade excedeu 255 caracteres. Esta declaração não deve "
+#~ "ter mais de 255 caracteres."
+
+#~ msgid ""
+#~ "Provided street address claim exceeded 255 characters. This claim should "
+#~ "not be longer than 255 characters"
+#~ msgstr ""
+#~ "O endereço fornecido excedeu 255 caracteres. Este endereço não deve ter "
+#~ "mais de 255 caracteres."

--- a/locales/samlSSO.pot
+++ b/locales/samlSSO.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: samlSSO 1.2.5\n"
+"Project-Id-Version: samlSSO 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/DonutsNL/samlSSO/issues\n"
-"POT-Creation-Date: 2025-11-27 12:28+0100\n"
+"POT-Creation-Date: 2026-05-31 01:33-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,170 +17,457 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: hook.php:84
+#: hook.php:104
 msgid "samlSSO exclusions"
 msgstr ""
 
-#: hook.php:129
+#: hook.php:163
 msgid "🆗 Installing version:"
 msgstr ""
 
-#: hook.php:133
+#: hook.php:187
+msgid ""
+"⚠️ PHP memory_limit is less than 512M. This may cause crashes during SAML "
+"Login. See: "
+msgstr ""
+
+#: hook.php:198
 msgid "⚠️ OpenSSL not available, cant verify provided certificates"
 msgstr ""
 
-#: hook.php:135
+#: hook.php:200
 msgid "🆗 OpenSSL found!"
 msgstr ""
 
-#: setup.php:199
+#: setup.php:227
 msgid "Installed "
 msgstr ""
 
-#: src/RuleSaml.php:80
-msgid "JIT rules"
-msgstr ""
-
-#: src/RuleSamlCollection.php:73 src/Config.php:148
+#: src/RuleSamlCollection.php:73 src/Config.php:151
 msgid "JIT import rules"
 msgstr ""
 
-#: src/CronTask.php:65
-msgid "Clean old SAML sessions"
+#: src/LoginFlow.php:170
+msgid "samlFlow"
 msgstr ""
 
-#: src/CronTask.php:66
-msgid "SAML sessions retention period (in days, 0 for infinite)"
+#: src/LoginFlow.php:258
+msgid "You have been forcefully logged out by an administrator."
 msgstr ""
 
-#: src/Config/ConfigItem.php:95 src/LoginFlow/LoginFlowItem.php:90
+#: src/LoginFlow.php:482
+msgid "Could not update the loginState and therefor stopped the loginFlow for:"
+msgstr ""
+
+#: src/LoginFlow.php:591
+#, php-format
+msgid ""
+"You have been authenticated using the SAML2 identity provider: <b>%1$s</b>."
+"<br><br>Because SAML authentication is enforced, logging out of GLPI locally "
+"will automatically log you back in immediately.<br><br>To sign out "
+"completely, please select <b>'Log out everywhere'</b>. Note that this will "
+"also terminate your active sessions in all other applications connected to "
+"this Identity Provider.<br><br>If you want to leave GLPI, just close this "
+"browser tab."
+msgstr ""
+
+#: src/LoginFlow.php:596
+#, php-format
+msgid ""
+"You have been authenticated using the SAML2 identity provider: <b>%1$s</b>."
+"<br><br>You can log out permanently by also logging out with the IDP by "
+"pressing <b>'Log out everywhere'</b> (which terminates active sessions in "
+"all other applications depending on it), or perform a local logout from GLPI "
+"only by pressing <b>'Continue GLPI logout'</b>."
+msgstr ""
+
+#: src/LoginFlow.php:603
+msgid "🤔 How do you like to proceed?"
+msgstr ""
+
+#: src/LoginFlow.php:606
+msgid "Continue with local logout"
+msgstr ""
+
+#: src/LoginFlow.php:608
+msgid "Close tab"
+msgstr ""
+
+#: src/LoginFlow.php:609
+msgid "Log out everywhere"
+msgstr ""
+
+#: src/LoginFlow.php:663
+msgid "Login with external provider"
+msgstr ""
+
+#: src/LoginFlow.php:715 src/LoginFlow.php:775
+msgid "An internal error occurred. Please contact your GLPI administrator."
+msgstr ""
+
+#: src/LoginFlow.php:718
+msgid "⚠️ Sorry we are unable to log you in"
+msgstr ""
+
+#: src/LoginFlow.php:723 src/LoginFlow.php:782
+msgid "Return to GLPI"
+msgstr ""
+
+#: src/LoginFlow.php:778
+msgid "⚠️ An error occurred"
+msgstr ""
+
+#: src/LoginFlow.php:779
+msgid "We are sorry, something went wrong while processing your request!"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:120
+msgid "IDP configuration ID must be a positive integer"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:140
+msgid "Invalid mapping target type"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:162
+msgid "Invalid GLPI field selected for target type"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:182
+msgid "SAML Claim key cannot be empty"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:184
+msgid "SAML Claim key cannot exceed 255 characters"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:204
+msgid "Default value must be a string"
+msgstr ""
+
+#: src/Config/ClaimMapItem.php:206
+msgid "Default value cannot exceed 255 characters"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:310
+msgid "SAML Claim key cannot be empty for Username mapping."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:318
+msgid "SAML Claim key cannot be empty for Email mapping."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:357
+#, php-format
+msgid "Duplicate mapping for %s: %s"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:373
+msgid "Username mapping is required and cannot be removed."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:377
+msgid "Email mapping is required and cannot be removed."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:480
+msgid "NameId attribute is missing in samlResponse"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:486
+msgid ""
+"Detected a default guest user in samlResponse, this is not supported by "
+"glpiSAML."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:531
+msgid ""
+"Warning: SAML NameId format was requested as email but observed value is not "
+"a valid email. Falling back to configured email field."
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:554
+msgid "invalid values where used to identify the user during auth"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:616
+#, php-format
+msgid "Required user field \"%s\" is missing or invalid in SAML response"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:658
+msgid "Required rule field \"groups\" is missing in SAML response"
+msgstr ""
+
+#: src/Config/ClaimMapEntity.php:705
+#, php-format
+msgid "Required rule field \"%s\" is missing or invalid in SAML response"
+msgstr ""
+
+#: src/Config/ConfigEntity.php:364
+msgid ""
+"⚠️ SP private key does not seem to match provided SP certificates modulus."
+msgstr ""
+
+#: src/Config/ConfigEntity.php:369
+msgid ""
+"⚠️ Will be defaulted to \"No\" because the provided SP certificate does not "
+"look valid!"
+msgstr ""
+
+#: src/Config/ConfigEntity.php:417
+msgid "⚠️ IDPs cannot be enforced if more than one is present in the IDP list."
+msgstr ""
+
+#: src/Config/ConfigForm.php:255
+msgid "Restore failed: no valid backup file was uploaded."
+msgstr ""
+
+#: src/Config/ConfigForm.php:261
+msgid "Restore failed: unable to read the uploaded file."
+msgstr ""
+
+#: src/Config/ConfigForm.php:298
+msgid "Restore failed: the backup file has an invalid or unrecognized format."
+msgstr ""
+
+#: src/Config/ConfigForm.php:338
+#, php-format
+msgid "Entry %d skipped: missing config block."
+msgstr ""
+
+#: src/Config/ConfigForm.php:346
+#, php-format
+msgid "Entry %d skipped: missing or invalid id."
+msgstr ""
+
+#: src/Config/ConfigForm.php:364
+#, php-format
+msgid "Entry %d (%s) could not be inserted into database."
+msgstr ""
+
+#: src/Config/ConfigForm.php:375
+#, php-format
+msgid "Config %s restored but claim mappings had validation errors."
+msgstr ""
+
+#: src/Config/ConfigForm.php:384
+#, php-format
+msgid "Restore successful: %d IDP configuration(s) restored."
+msgstr ""
+
+#: src/Config/ConfigForm.php:393
+msgid "Restore completed but no configurations were imported."
+msgstr ""
+
+#: src/Config/ConfigForm.php:411
+msgid "You do not have permission to perform this action."
+msgstr ""
+
+#: src/Config/ConfigForm.php:426
+msgid "User disabled and session forced logoff."
+msgstr ""
+
+#: src/Config/ConfigForm.php:428
+msgid "Login state session not found."
+msgstr ""
+
+#: src/Config/ConfigForm.php:517
+msgid "Successfully added new samlSSO configuration."
+msgstr ""
+
+#: src/Config/ConfigForm.php:521
+msgid "Unable to add new samlSSO configuration, please review error logging"
+msgstr ""
+
+#: src/Config/ConfigForm.php:526 src/Config/ConfigForm.php:571
+msgid "Configuration invalid, please correct all ⭕ errors first"
+msgstr ""
+
+#: src/Config/ConfigForm.php:562 src/LoginFlow/LoginFlowForm.php:105
+msgid "Configuration updated successfully"
+msgstr ""
+
+#: src/Config/ConfigForm.php:566 src/LoginFlow/LoginFlowForm.php:109
+msgid "Configuration update failed, check your update rights or error logging"
+msgstr ""
+
+#: src/Config/ConfigForm.php:591
+msgid "Configuration deleted successfully"
+msgstr ""
+
+#: src/Config/ConfigForm.php:595
+msgid "Not allowed or error deleting SAML configuration!"
+msgstr ""
+
+#: src/Config/ConfigForm.php:614 src/LoginFlow/LoginFlowForm.php:133
+msgid "Invalid request, redirecting back"
+msgstr ""
+
+#: src/Config/ConfigForm.php:740
+msgid "This claim key has not been observed in any SAML responses yet."
+msgstr ""
+
+#: src/Config/ConfigForm.php:792 src/LoginFlow/LoginFlowForm.php:184
+msgid "Email Address"
+msgstr ""
+
+#: src/Config/ConfigForm.php:793 src/LoginFlow/LoginFlowForm.php:185
+msgid "Transient"
+msgstr ""
+
+#: src/Config/ConfigForm.php:794 src/LoginFlow/LoginFlowForm.php:186
+msgid "Persistent"
+msgstr ""
+
+#: src/Config/ConfigForm.php:795 src/LoginFlow/LoginFlowForm.php:189
+msgid "PasswordProtectedTransport"
+msgstr ""
+
+#: src/Config/ConfigForm.php:797 src/LoginFlow/LoginFlowForm.php:191
+msgid "X509"
+msgstr ""
+
+#: src/Config/ConfigForm.php:798 src/LoginFlow/LoginFlowForm.php:192
+msgid "none"
+msgstr ""
+
+#: src/Config/ConfigForm.php:799 src/LoginFlow/LoginFlowForm.php:195
+msgid "Exact"
+msgstr ""
+
+#: src/Config/ConfigForm.php:802 src/LoginFlow/LoginFlowForm.php:198
+msgid "Better"
+msgstr ""
+
+#: src/Config/ConfigItem.php:101 src/LoginFlow/LoginFlowItem.php:97
 msgid "⭕ ID must be a positive numeric value!"
 msgstr ""
 
-#: src/Config/ConfigItem.php:98 src/LoginFlow/LoginFlowItem.php:93
+#: src/Config/ConfigItem.php:105 src/LoginFlow/LoginFlowItem.php:101
 msgid "Unique identifier for this configuration"
 msgstr ""
 
-#: src/Config/ConfigItem.php:99 src/LoginFlow/LoginFlowItem.php:94
+#: src/Config/ConfigItem.php:106 src/LoginFlow/LoginFlowItem.php:102
 msgid "CONFIG ID"
 msgstr ""
 
-#: src/Config/ConfigItem.php:112
+#: src/Config/ConfigItem.php:120
 msgid ""
 "This name is shown with the login button on the login page. Try to keep this "
 "name short en to the point."
 msgstr ""
 
-#: src/Config/ConfigItem.php:113
+#: src/Config/ConfigItem.php:121
 msgid "FRIENDLY NAME"
 msgstr ""
 
-#: src/Config/ConfigItem.php:118
+#: src/Config/ConfigItem.php:126
 msgid "⭕ Name is a required field"
 msgstr ""
 
-#: src/Config/ConfigItem.php:127
+#: src/Config/ConfigItem.php:137
 msgid "USERDOMAIN"
 msgstr ""
 
-#: src/Config/ConfigItem.php:132
+#: src/Config/ConfigItem.php:142
 msgid "⭕ "
 msgstr ""
 
-#: src/Config/ConfigItem.php:147
+#: src/Config/ConfigItem.php:159
 msgid ""
 "⭕ Provided certificate does not like look a valid (base64 encoded) "
 "certificate"
 msgstr ""
 
-#: src/Config/ConfigItem.php:151
+#: src/Config/ConfigItem.php:164
 msgid ""
 "The base64 encoded x509 service provider certificate. Used to sign and "
 "encrypt messages send by the service provider to the identity provider. "
 "Required for most of the security options"
 msgstr ""
 
-#: src/Config/ConfigItem.php:152
+#: src/Config/ConfigItem.php:165
 msgid "SP CERTIFICATE"
 msgstr ""
 
-#: src/Config/ConfigItem.php:167
+#: src/Config/ConfigItem.php:182
 msgid ""
 "The base64 encoded x509 service providers private key. Should match the "
 "modulus of the provided X509 service provider certificate"
 msgstr ""
 
-#: src/Config/ConfigItem.php:168
+#: src/Config/ConfigItem.php:183
 msgid "SP PRIVATE KEY"
 msgstr ""
 
-#: src/Config/ConfigItem.php:179
+#: src/Config/ConfigItem.php:196
 msgid ""
 "The Service Provider nameid format specifies the constraints on the name "
 "identifier to be used to represent the requested subject."
 msgstr ""
 
-#: src/Config/ConfigItem.php:180
+#: src/Config/ConfigItem.php:197
 msgid "NAMEID FORMAT"
 msgstr ""
 
-#: src/Config/ConfigItem.php:185
+#: src/Config/ConfigItem.php:202
 msgid "Service provider name id is a required field"
 msgstr ""
 
-#: src/Config/ConfigItem.php:192
+#: src/Config/ConfigItem.php:211
 msgid ""
 "Identifier of the IdP entity which is an URL provided by the SAML2 Identity "
 "Provider (IdP)"
 msgstr ""
 
-#: src/Config/ConfigItem.php:193
+#: src/Config/ConfigItem.php:212
 msgid "ENTITY ID"
 msgstr ""
 
-#: src/Config/ConfigItem.php:198
+#: src/Config/ConfigItem.php:217
 msgid "⭕ Identity provider entity id is a required field"
 msgstr ""
 
-#: src/Config/ConfigItem.php:211
+#: src/Config/ConfigItem.php:231
 msgid "⭕ The IdP SSO URL is a required field!<br>"
 msgstr ""
 
-#: src/Config/ConfigItem.php:216
+#: src/Config/ConfigItem.php:236
 msgid "⭕ Invalid IdP SSO URL, use: scheme://host.domain.tld/path/"
 msgstr ""
 
-#: src/Config/ConfigItem.php:223
+#: src/Config/ConfigItem.php:244
 msgid ""
 "Single Sign On Service endpoint of the IdP. URL Target of the IdP where the "
 "Authentication Request Message will be sent. OneLogin PHPSAML only supports "
 "the 'HTTP-redirect' binding for this endpoint."
 msgstr ""
 
-#: src/Config/ConfigItem.php:224
+#: src/Config/ConfigItem.php:245
 msgid "SSO URL"
 msgstr ""
 
-#: src/Config/ConfigItem.php:246
+#: src/Config/ConfigItem.php:268
 msgid "⭕ Invalid Idp SLO URL, use: scheme://host.domain.tld/path/"
 msgstr ""
 
-#: src/Config/ConfigItem.php:249
+#: src/Config/ConfigItem.php:272
 msgid ""
 "Single Logout service endpoint of the IdP. URL Location of the IdP where SLO "
 "Request will be sent.OneLogin PHPSAML only supports the 'HTTP-redirect' "
 "binding for this endpoint."
 msgstr ""
 
-#: src/Config/ConfigItem.php:250
+#: src/Config/ConfigItem.php:273
 msgid "SLO URL"
 msgstr ""
 
-#: src/Config/ConfigItem.php:269
+#: src/Config/ConfigItem.php:294
 msgid "⭕ Valid Idp X509 certificate is required! (base64 encoded)"
 msgstr ""
 
-#: src/Config/ConfigItem.php:273
+#: src/Config/ConfigItem.php:299
 msgid ""
 "The Public Base64 encoded x509 certificate used by the IdP. Fingerprinting "
 "can be used, but is not recommended. Fingerprinting requires you to manually "
@@ -188,11 +475,11 @@ msgid ""
 "required configuration options"
 msgstr ""
 
-#: src/Config/ConfigItem.php:274
+#: src/Config/ConfigItem.php:300
 msgid "X509 CERTIFICATE"
 msgstr ""
 
-#: src/Config/ConfigItem.php:299
+#: src/Config/ConfigItem.php:327
 msgid ""
 "Authentication context needs to be satisfied by the IdP in order to allow "
 "Saml login. Set to \"none\" and OneLogin PHPSAML will not send an "
@@ -200,83 +487,90 @@ msgid ""
 "\"control+click\" combination."
 msgstr ""
 
-#: src/Config/ConfigItem.php:300
+#: src/Config/ConfigItem.php:328
 msgid "REQ AUTHN CONTEXT"
 msgstr ""
 
-#: src/Config/ConfigItem.php:305
+#: src/Config/ConfigItem.php:333
 msgid "⭕ Requested authN context is a required field"
 msgstr ""
 
-#: src/Config/ConfigItem.php:310
+#: src/Config/ConfigItem.php:340
 msgid "AUTHN Comparison attribute value"
 msgstr ""
 
-#: src/Config/ConfigItem.php:311
+#: src/Config/ConfigItem.php:341
 msgid "AUTHN COMPARISON"
 msgstr ""
 
-#: src/Config/ConfigItem.php:316
+#: src/Config/ConfigItem.php:346
 msgid "⭕ Requested authN context comparison is a required field"
 msgstr ""
 
-#: src/Config/ConfigItem.php:321
-msgid ""
-"The FontAwesome (https://fontawesome.com/) icon to show on the button on the "
-"login page."
+#: src/Config/ConfigItem.php:353
+#, php-format
+msgid "The FontAwesome (%s) icon to show on the button on the login page."
 msgstr ""
 
-#: src/Config/ConfigItem.php:322
+#: src/Config/ConfigItem.php:354
 msgid "LOGIN ICON"
 msgstr ""
 
-#: src/Config/ConfigItem.php:327
+#: src/Config/ConfigItem.php:359
 msgid "⭕ Configuration icon is a required field"
 msgstr ""
 
-#: src/Config/ConfigItem.php:332
+#: src/Config/ConfigItem.php:366
 msgid "The comments"
 msgstr ""
 
-#: src/Config/ConfigItem.php:333
+#: src/Config/ConfigItem.php:367
 msgid "COMMENTS"
 msgstr ""
 
-#: src/Config/ConfigItem.php:344
+#: src/Config/ConfigItem.php:379
+msgid "The anonymized SAML response XML structure"
+msgstr ""
+
+#: src/Config/ConfigItem.php:380
+msgid "SAML Response XML Structure"
+msgstr ""
+
+#: src/Config/ConfigItem.php:393
 msgid "The date this configuration item was created"
 msgstr ""
 
-#: src/Config/ConfigItem.php:345
+#: src/Config/ConfigItem.php:394
 msgid "CREATE DATE"
 msgstr ""
 
-#: src/Config/ConfigItem.php:357
+#: src/Config/ConfigItem.php:408
 msgid "The date this config was modified"
 msgstr ""
 
-#: src/Config/ConfigItem.php:358
+#: src/Config/ConfigItem.php:409
 msgid "MODIFICATION DATE"
 msgstr ""
 
-#: src/Config/ConfigItem.php:373
+#: src/Config/ConfigItem.php:429
 msgid "Is this configuration marked as deleted by GLPI"
 msgstr ""
 
-#: src/Config/ConfigItem.php:374
+#: src/Config/ConfigItem.php:430
 msgid "IS DELETED"
 msgstr ""
 
-#: src/Config/ConfigItem.php:382
+#: src/Config/ConfigItem.php:442
 msgid ""
 "Indicates if this configuration activated. Disabled configurations cannot be "
 "used to login into GLPI and will NOT be shown on the login page."
 msgstr ""
 
-#: src/Config/ConfigItem.php:383
+#: src/Config/ConfigItem.php:443
 msgid "IS ACTIVE"
 msgstr ""
 
-#: src/Config/ConfigItem.php:391
+#: src/Config/ConfigItem.php:455
 msgid ""
 "If enabled PHPSAML will replace the default GLPI login screen with a version "
 "that does not have the default GLPI login options and only allows the user "
@@ -284,19 +578,19 @@ msgid ""
 "bypassed using a bypass URI parameter"
 msgstr ""
 
-#: src/Config/ConfigItem.php:392
+#: src/Config/ConfigItem.php:456
 msgid "ENFORCED"
 msgstr ""
 
-#: src/Config/ConfigItem.php:400
+#: src/Config/ConfigItem.php:468
 msgid "Is GLPI positioned behind a proxy that alters the SAML response scheme?"
 msgstr ""
 
-#: src/Config/ConfigItem.php:401
+#: src/Config/ConfigItem.php:469
 msgid "REQUESTS PROXIED"
 msgstr ""
 
-#: src/Config/ConfigItem.php:409
+#: src/Config/ConfigItem.php:481
 msgid ""
 "If enabled the OneLogin PHPSAML Toolkit will reject unsigned or unencrypted "
 "messages if it expects them to be signed or encrypted. Also it will reject "
@@ -305,18 +599,18 @@ msgid ""
 "environments."
 msgstr ""
 
-#: src/Config/ConfigItem.php:410
+#: src/Config/ConfigItem.php:482
 msgid "STRICT"
 msgstr ""
 
-#: src/Config/ConfigItem.php:418
+#: src/Config/ConfigItem.php:494
 msgid ""
 "If enabled it will enforce OneLogin PHPSAML to print status and error "
 "messages. Be aware that not all message's might be captured by samlSSO and "
 "might therefor not become visible."
 msgstr ""
 
-#: src/Config/ConfigItem.php:427
+#: src/Config/ConfigItem.php:507
 msgid ""
 "If enabled samlSSO will create new GLPI users on the fly and assign the "
 "properties defined in the samlSSO assignment rules. If disables users that "
@@ -324,72 +618,132 @@ msgid ""
 "user is manually created."
 msgstr ""
 
-#: src/Config/ConfigItem.php:428
+#: src/Config/ConfigItem.php:508
 msgid "JIT USER CREATION"
 msgstr ""
 
-#: src/Config/ConfigItem.php:436
+#: src/Config/ConfigItem.php:526
 msgid ""
-"If enabled the OneLogin PHPSAML toolkit will encrypt the <samlp:"
-"logoutRequest> sent by this SP using the provided SP certificate and private "
-"key. This option will be toggled \"off\" automatically if no, or no valid SP "
-"certificate and key is provided."
+"If enabled, user fields mapped from SAML claims and assignment rules will be "
+"synchronized on every successful login."
 msgstr ""
 
-#: src/Config/ConfigItem.php:437
+#: src/Config/ConfigItem.php:527
+msgid "SYNC ON LOGIN"
+msgstr ""
+
+#: src/Config/ConfigItem.php:545
+msgid ""
+"If enabled, GLPI will require all SAML protocol messages received from the "
+"Identity Provider (IdP) to be cryptographically signed."
+msgstr ""
+
+#: src/Config/ConfigItem.php:546
+msgid "REQUIRE SIGNED MESSAGES"
+msgstr ""
+
+#: src/Config/ConfigItem.php:564
+msgid ""
+"If enabled, GLPI will require individual SAML assertions within the SAML "
+"message to be signed. If unsigned, assertions will be rejected."
+msgstr ""
+
+#: src/Config/ConfigItem.php:565
+msgid "REQUIRE SIGNED ASSERTIONS"
+msgstr ""
+
+#: src/Config/ConfigItem.php:583
+msgid ""
+"If enabled, GLPI will expect the SAML assertions containing user claims to "
+"be encrypted. GLPI will decrypt them using the SP private key."
+msgstr ""
+
+#: src/Config/ConfigItem.php:584
+msgid "REQUIRE ENCRYPTED ASSERTIONS"
+msgstr ""
+
+#: src/Config/ConfigItem.php:602
+msgid ""
+"If enabled, the SAML SP metadata XML generated by GLPI will be "
+"cryptographically signed using the Service Provider certificate."
+msgstr ""
+
+#: src/Config/ConfigItem.php:603
+msgid "SIGN SP METADATA"
+msgstr ""
+
+#: src/Config/ConfigItem.php:621
+msgid ""
+"If enabled, GLPI will strictly require a NameID element to be present in the "
+"SAML assertion payload."
+msgstr ""
+
+#: src/Config/ConfigItem.php:622
+msgid "REQUIRE NAMEID"
+msgstr ""
+
+#: src/Config/ConfigItem.php:634
+msgid ""
+"If enabled the OneLogin PHPSAML toolkit will encrypt the "
+"<samlp:logoutRequest> sent by this SP using the provided SP certificate and "
+"private key. This option will be toggled \"off\" automatically if no, or no "
+"valid SP certificate and key is provided."
+msgstr ""
+
+#: src/Config/ConfigItem.php:635
 msgid "ENCRYPT NAMEID"
 msgstr ""
 
-#: src/Config/ConfigItem.php:445
+#: src/Config/ConfigItem.php:647
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will sign the <samlp:AuthnRequest> "
 "messages send by this SP. The IDP should consult the metadata to get the "
 "information required to validate the signatures."
 msgstr ""
 
-#: src/Config/ConfigItem.php:446
+#: src/Config/ConfigItem.php:648
 msgid "SIGN AUTHN REQUEST"
 msgstr ""
 
-#: src/Config/ConfigItem.php:454
+#: src/Config/ConfigItem.php:660
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutRequest> "
 "messages send by this SP."
 msgstr ""
 
-#: src/Config/ConfigItem.php:455
+#: src/Config/ConfigItem.php:661
 msgid "SIGN LOGOUT REQUEST"
 msgstr ""
 
-#: src/Config/ConfigItem.php:463
+#: src/Config/ConfigItem.php:673
 msgid ""
 "If enabled the OneLogin PHPSAML toolkit will sign the <samlp:logoutResponse> "
 "messages send by this SP."
 msgstr ""
 
-#: src/Config/ConfigItem.php:464
+#: src/Config/ConfigItem.php:674
 msgid "SIGN LOGOUT RESPONSE"
 msgstr ""
 
-#: src/Config/ConfigItem.php:472
+#: src/Config/ConfigItem.php:686
 msgid ""
 "If enabled the authentication requests send to the IdP will be compressed by "
 "the SP."
 msgstr ""
 
-#: src/Config/ConfigItem.php:473
+#: src/Config/ConfigItem.php:687
 msgid "COMPRESS REQUESTS"
 msgstr ""
 
-#: src/Config/ConfigItem.php:481
+#: src/Config/ConfigItem.php:699
 msgid "If enabled the SP expects responses send by the IdP to be compressed."
 msgstr ""
 
-#: src/Config/ConfigItem.php:482
+#: src/Config/ConfigItem.php:700
 msgid "COMPRESS RESPONSES"
 msgstr ""
 
-#: src/Config/ConfigItem.php:490
+#: src/Config/ConfigItem.php:712
 msgid ""
 "If enabled the SP will validate all received XMLs. In order to validate the "
 "XML\n"
@@ -397,371 +751,97 @@ msgid ""
 "setting must be true."
 msgstr ""
 
-#: src/Config/ConfigItem.php:492
+#: src/Config/ConfigItem.php:714
 msgid "VALIDATE XML"
 msgstr ""
 
-#: src/Config/ConfigItem.php:500
+#: src/Config/ConfigItem.php:726
 msgid ""
 "If enabled, SAMLResponses with an empty value at its Destination attribute "
 "will not be rejected for this fact."
 msgstr ""
 
-#: src/Config/ConfigItem.php:501
+#: src/Config/ConfigItem.php:727
 msgid "RELAX DEST VALIDATION"
 msgstr ""
 
-#: src/Config/ConfigItem.php:509
+#: src/Config/ConfigItem.php:739
 msgid ""
 "ADFS URL-Encodes SAML data as lowercase, and the OneLogin PHPSAML toolkit by "
 "default uses uppercase. Enable this setting for ADFS compatibility on "
 "signature verification"
 msgstr ""
 
-#: src/Config/ConfigItem.php:510
+#: src/Config/ConfigItem.php:740
 msgid "LOWER CASE ENCODING"
 msgstr ""
 
-#: src/Config/ConfigItem.php:564
+#: src/Config/ConfigItem.php:800
 msgid ""
 "⚠️ Warning, do not use the 'withlove.from.donuts.nl' example certificates. "
 "They offer no additional protection."
 msgstr ""
 
-#: src/Config/ConfigItem.php:572
+#: src/Config/ConfigItem.php:810
 msgid ""
 "⭕ Certificate must be wrapped in valid BEGIN CERTIFICATE and END "
 "CERTIFICATE tags"
 msgstr ""
 
-#: src/Config/ConfigItem.php:576
+#: src/Config/ConfigItem.php:816
 msgid "⭕ Certificate should not contain \"carriage returns\" [<CR>]"
 msgstr ""
 
-#: src/Config/ConfigItem.php:580
+#: src/Config/ConfigItem.php:820
 msgid "⭕ No valid X509 certificate found"
 msgstr ""
 
-#: src/Config/ConfigItem.php:583
+#: src/Config/ConfigItem.php:823
 msgid "⚠️ OpenSSL is not available, GLPI cant validate your certificate"
 msgstr ""
 
-#: src/Config/ConfigForm.php:159
-msgid "Successfully added new samlSSO configuration."
-msgstr ""
-
-#: src/Config/ConfigForm.php:163
-msgid "Unable to add new samlSSO configuration, please review error logging"
-msgstr ""
-
-#: src/Config/ConfigForm.php:168
-msgid "Configuration invalid, please correct all ⭕ errors first"
-msgstr ""
-
-#: src/Config/ConfigForm.php:196 src/LoginFlow/LoginFlowForm.php:100
-msgid "Configuration updated successfully"
-msgstr ""
-
-#: src/Config/ConfigForm.php:200 src/LoginFlow/LoginFlowForm.php:104
-msgid "Configuration update failed, check your update rights or error logging"
-msgstr ""
-
-#: src/Config/ConfigForm.php:205 src/LoginFlow/LoginFlowForm.php:109
-msgid "Configuration invalid please correct all ⭕ errors first"
-msgstr ""
-
-#: src/Config/ConfigForm.php:225
-msgid "Configuration deleted successfully"
-msgstr ""
-
-#: src/Config/ConfigForm.php:229
-msgid "Not allowed or error deleting SAML configuration!"
-msgstr ""
-
-#: src/Config/ConfigForm.php:248 src/LoginFlow/LoginFlowForm.php:128
-msgid "Invalid request, redirecting back"
-msgstr ""
-
-#: src/Config/ConfigForm.php:357 src/LoginFlow/LoginFlowForm.php:176
-msgid "Email Address"
-msgstr ""
-
-#: src/Config/ConfigForm.php:358 src/LoginFlow/LoginFlowForm.php:177
-msgid "Transient"
-msgstr ""
-
-#: src/Config/ConfigForm.php:359 src/LoginFlow/LoginFlowForm.php:178
-msgid "Persistent"
-msgstr ""
-
-#: src/Config/ConfigForm.php:360 src/LoginFlow/LoginFlowForm.php:179
-msgid "PasswordProtectedTransport"
-msgstr ""
-
-#: src/Config/ConfigForm.php:362 src/LoginFlow/LoginFlowForm.php:181
-msgid "X509"
-msgstr ""
-
-#: src/Config/ConfigForm.php:363 src/LoginFlow/LoginFlowForm.php:182
-msgid "none"
-msgstr ""
-
-#: src/Config/ConfigForm.php:364 src/LoginFlow/LoginFlowForm.php:183
-msgid "Exact"
-msgstr ""
-
-#: src/Config/ConfigForm.php:367 src/LoginFlow/LoginFlowForm.php:186
-msgid "Better"
-msgstr ""
-
-#: src/Config/ConfigEntity.php:344
-msgid ""
-"⚠️ SP private key does not seem to match provided SP certificates modulus."
-msgstr ""
-
-#: src/Config/ConfigEntity.php:349
-msgid ""
-"⚠️ Will be defaulted to \"No\" because the provided SP certificate does not "
-"look valid!"
-msgstr ""
-
-#: src/LoginFlow.php:162
-msgid "samlFlow"
-msgstr ""
-
-#: src/LoginFlow.php:406
-msgid "Could not update the loginState and therefor stopped the loginFlow for:"
-msgstr ""
-
-#: src/LoginFlow.php:495
-msgid "⚠️ Are you sure?"
-msgstr ""
-
-#: src/LoginFlow.php:497
-msgid "Continue GLPI logout"
-msgstr ""
-
-#: src/LoginFlow.php:499
-msgid "Log out everywhere"
-msgstr ""
-
-#: src/LoginFlow.php:549
-msgid "Login with external provider"
-msgstr ""
-
-#: src/LoginFlow.php:584
-msgid "⚠️ Sorry we are unable to log you in"
-msgstr ""
-
-#: src/LoginFlow.php:589 src/LoginFlow.php:629
-msgid "Return to GLPI"
-msgstr ""
-
-#: src/LoginFlow.php:625
-msgid "⚠️ An error occurred"
-msgstr ""
-
-#: src/Config.php:123
+#: src/Config.php:125
 msgid "samlSSO"
 msgstr ""
 
-#: src/Config.php:146 src/Exclude.php:86
+#: src/Config.php:149 src/Exclude.php:87
 msgid "Excluded paths"
 msgstr ""
 
-#: src/Config.php:181
+#: src/Config.php:184
 msgid "Idp entity ID"
 msgstr ""
 
-#: src/LoginFlow/Acs.php:133
-msgid "Unable to fetch idp configuration with id:"
+#: src/CronTask.php:66
+msgid "Clean old SAML sessions"
 msgstr ""
 
-#: src/LoginFlow/Acs.php:134
-msgid "Assert saml"
+#: src/CronTask.php:67
+msgid "SAML sessions retention period (in days, 0 for infinite)"
 msgstr ""
 
-#: src/LoginFlow/Acs.php:151 src/LoginFlow/Acs.php:165
-msgid "phpSaml::Settings->init"
+#: src/CronTask.php:69
+msgid "Update GeoIP offline database"
 msgstr ""
 
-#: src/LoginFlow/Acs.php:178
-msgid "Could not process samlResponse with Error:"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:179
-msgid "Saml::Response->init"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:193
-msgid "LoginState"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:202
-msgid ""
-"The received idp response did not contain the required samlResponse POST "
-"body or idpId to authenticate the user, see: https://codeberg.org/QuinQuies/"
-"glpisaml/wiki/ACS.php for more information"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:203
-msgid "Acs assertion"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:226
-msgid ""
-"It looks like this samlResponse has already been used to authenticate a "
-"different user.\n"
-"                                 Maybe an error occurred and you pressed F5 "
-"and accidently resend the samlResponse that is\n"
-"                                 already registered as processed. For "
-"security reasons we can not allow processed samlResponses\n"
-"                                 to be processed again. Please login again "
-"to generate a new samlResponse. Sorry for any inconvenience.\n"
-"                                 If the problem presists, then please "
-"contact your administrator.\n"
-"                                 See: https://codeberg.org/QuinQuies/"
-"glpisaml/wiki/LoginState.php for more information"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:246
-msgid ""
-"An error occured while trying to update the samlResponseId into the "
-"LoginState database. Review the saml log for more details"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:257
-msgid ""
-"GLPI did not expect an assertion from this Idp. The most likely reason is a "
-"race condition\n"
-"                                  causing an inconsistant loginState in the "
-"database or software bug. Please login again via the\n"
-"                                  GLPI-interface. Sorry for the "
-"inconvenience. See: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState."
-"php\n"
-"                                  for more information"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:261
-msgid "samlResponse assertion"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:274
-msgid ""
-"An error occured while trying to update the login phase to LoginState::"
-"PHASE_SAML_AUTH  into the LoginState database.\n"
-"                                  Review the saml log for more details"
-msgstr ""
-
-#: src/LoginFlow/Acs.php:282
-msgid ""
-"Validation of the samlResponse document failed. Review the saml log for more "
-"details"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:110
-msgid "⭕ IDP ID must be a positive numeric value!"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:113
-msgid "What IDP ID should be enforced?"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:114
-msgid "ENFORCED IDP ID"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:129
-msgid "Debug enabled?"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:140
-msgid ""
-"Should SAML SSO be enforced. This option can be bypassed by the bypass var "
-"and value"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:141
-msgid "ENFORCE SSO"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:151
-msgid "Try to match domain in username for IDP selection"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:152
-msgid "ENABLE DOMAIN BASED SSO"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:162
-msgid "Allow the ?idpId=[val] URI to pre select IDP from URLs"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:163
-msgid "Enable getter login"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:173
-msgid ""
-"Hide the default GLPI login options. This option can be bypassed using the "
-"bypass var and value."
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:174
-msgid "HIDE GLPI LOGIN"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:184
-msgid ""
-"Hides Saml Buttons. This option cannot be used together with the Hide GLPI "
-"login."
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:185
-msgid "Hide Saml Buttons"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:195
-msgid "Hide the GLPI password field. To be used with Enable Domain Login."
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:196
-msgid "HIDE PASSWORD FIELD"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:206
-msgid "Forces samlSSO to (re)apply the rules on each succesfull auth."
-msgstr ""
-
-#: src/LoginFlow/LoginFlowItem.php:207
-msgid "APPLY RULES ON AUTH"
-msgstr ""
-
-#: src/LoginFlow/Meta.php:76
-msgid "Error fetching spMetedata."
-msgstr ""
-
-#: src/LoginFlow/Meta.php:81
-msgid "Invalid id or metadata not exposed."
-msgstr ""
-
-#: src/LoginFlow/Meta.php:86
-msgid "Error fetching config."
-msgstr ""
-
-#: src/LoginFlow/User.php:165 src/LoginFlow/User.php:173
+#: src/LoginFlow/User.php:170 src/LoginFlow/User.php:175
 msgid "User with GlpiUserid: "
 msgstr ""
 
-#: src/LoginFlow/User.php:189
+#: src/LoginFlow/User.php:187
 msgid ""
-"Your SSO login was successful but we where not able to fetch\n"
-"                                            the loginState from the database "
-"and could not continue to log\n"
-"                                            you into GLPI."
+"Your SSO login was successful but no GLPI profile was assigned to your "
+"account. Please contact your GLPI administrator to assign a profile to your "
+"account."
 msgstr ""
 
-#: src/LoginFlow/User.php:200
+#: src/LoginFlow/User.php:212
+msgid ""
+"Your SSO login was successful but the identity provider configuration is "
+"invalid or disabled."
+msgstr ""
+
+#: src/LoginFlow/User.php:221
 msgid ""
 "Your SSO login was successful but there is no matching GLPI user account "
 "and\n"
@@ -773,200 +853,396 @@ msgid ""
 "create a GLPI user manually."
 msgstr ""
 
-#: src/LoginFlow/User.php:222
+#: src/LoginFlow/User.php:234
+msgid ""
+"Your SSO login was successful but no GLPI profile was assigned to your "
+"account and\n"
+"                                                    we failed to assign one "
+"dynamically using Just In Time user creation. Please\n"
+"                                                    request a GLPI "
+"administrator to review the logs and correct the problem or\n"
+"                                                    request the "
+"administrator to assign a GLPI profile manually."
+msgstr ""
+
+#: src/LoginFlow/User.php:242
 msgid ""
 "Critical error: samlSSO was unable to fetch newly created user from the "
 "database!"
 msgstr ""
 
-#: src/LoginFlow/User.php:239
+#: src/LoginFlow/User.php:264
 msgid "JIT was called with params:"
 msgstr ""
 
-#: src/LoginFlow/User.php:250
+#: src/LoginFlow/User.php:333
+msgid "Created by phpSaml Just-In-Time user creation on:"
+msgstr ""
+
+#: src/LoginFlow/User.php:486
+msgid "JIT group already assigned:"
+msgstr ""
+
+#: src/LoginFlow/User.php:497
 msgid "JIT failed to assign groupID:"
 msgstr ""
 
-#: src/LoginFlow/User.php:252
+#: src/LoginFlow/User.php:502
 msgid "JIT assigned groupID:"
 msgstr ""
 
-#: src/LoginFlow/User.php:255
+#: src/LoginFlow/User.php:509
 msgid "JIT found no groupId to add.\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:269
+#: src/LoginFlow/User.php:533
 msgid "JIT found entity for profile assignment:"
 msgstr ""
 
-#: src/LoginFlow/User.php:271
+#: src/LoginFlow/User.php:535
 msgid ""
 "JIT didnt find a profile for entity assignment. Profile asignment might not "
 "work.\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:277
+#: src/LoginFlow/User.php:541
 msgid "JIT found to be assigned profile(s) to be recursive.\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:279
+#: src/LoginFlow/User.php:543
 msgid "JIT didnt find to be assigned profile(s) to be recursive.\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:283
-msgid "JIT remove all existing and default profiles from newly created user:\n"
+#: src/LoginFlow/User.php:560
+msgid "JIT profile already assigned with config:"
 msgstr ""
 
-#: src/LoginFlow/User.php:289
-msgid "Done\n"
-msgstr ""
-
-#: src/LoginFlow/User.php:291
-msgid "failed\n"
-msgstr ""
-
-#: src/LoginFlow/User.php:298
+#: src/LoginFlow/User.php:566
 msgid "JIT was not able to assign profile with config:"
 msgstr ""
 
-#: src/LoginFlow/User.php:300
+#: src/LoginFlow/User.php:572
+msgid "JIT remove all default profiles from newly created user:\n"
+msgstr ""
+
+#: src/LoginFlow/User.php:580
+msgid "Done\n"
+msgstr ""
+
+#: src/LoginFlow/User.php:582
+msgid "failed\n"
+msgstr ""
+
+#: src/LoginFlow/User.php:584
 msgid "JIT assigned profile with config:"
 msgstr ""
 
-#: src/LoginFlow/User.php:313
+#: src/LoginFlow/User.php:617
 msgid "JIT found default groupID:"
 msgstr ""
 
-#: src/LoginFlow/User.php:315
+#: src/LoginFlow/User.php:619
 msgid "Jit didnt find a default GroupID to assign, skipping\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:320
+#: src/LoginFlow/User.php:624
 msgid "JIT found default entityID:"
 msgstr ""
 
-#: src/LoginFlow/User.php:322
+#: src/LoginFlow/User.php:626
 msgid "Jit didnt find a default EntityId to assign, skipping\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:327
+#: src/LoginFlow/User.php:631
 msgid "JIT found default profileID:"
 msgstr ""
 
-#: src/LoginFlow/User.php:329
+#: src/LoginFlow/User.php:633
 msgid "Jit didnt find a default ProfileId to assign, skipping\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:334
+#: src/LoginFlow/User.php:638
+msgid "JIT found timezone:"
+msgstr ""
+
+#: src/LoginFlow/User.php:643
+msgid "JIT found is_active:"
+msgstr ""
+
+#: src/LoginFlow/User.php:648
+msgid "JIT found locations_id:"
+msgstr ""
+
+#: src/LoginFlow/User.php:653
+msgid "JIT found usercategories_id:"
+msgstr ""
+
+#: src/LoginFlow/User.php:658
+msgid "JIT found usertitles_id:"
+msgstr ""
+
+#: src/LoginFlow/User.php:663
+msgid "JIT found language:"
+msgstr ""
+
+#: src/LoginFlow/User.php:668
 msgid "Jit updated user defaults\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:336
+#: src/LoginFlow/User.php:670
 msgid "Jit didnt update user defaults\n"
 msgstr ""
 
-#: src/LoginFlow/User.php:380
-msgid "NameId attribute is missing in samlResponse"
+#: src/LoginFlow/Meta.php:76
+msgid "Error fetching spMetadata."
 msgstr ""
 
-#: src/LoginFlow/User.php:389
+#: src/LoginFlow/Meta.php:81
+msgid "Invalid id or metadata not exposed."
+msgstr ""
+
+#: src/LoginFlow/Meta.php:86
+msgid "Error fetching config."
+msgstr ""
+
+#: src/LoginFlow/Acs.php:140
+msgid "Unable to fetch idp configuration with id:"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:141
+msgid "Samlsso->acs->init->FetchConfig"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:156
+#, php-format
 msgid ""
-"Detected a default guest user in samlResponse, this is not supported<br>\n"
-"                                      by glpiSAML. Please create a dedicated "
-"account for this user owned by your\n"
-"                                      tenant/identity provider.<br>\n"
-"                                      Also see: https://learn.microsoft.com/"
-"en-us/azure/active-directory/develop/saml-claims-customization"
+"The received idp response did not contain the required samlResponse POST "
+"body or idpId to authenticate the user, see: %s for more information"
 msgstr ""
 
-#: src/LoginFlow/User.php:422
+#: src/LoginFlow/Acs.php:157
+msgid "Samlsso->acs->init->NoSamlResponse"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:179
+msgid "Samlsso->acs->init->phpsaml->Utils->setProxyVars"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:198
 msgid ""
-"SamlResponse should have at least 1 valid email address for GLPI  to find\n"
-"                                          the corresponding GLPI user or "
-"create it (with JIT enabled). For this purpose make\n"
-"                                          sure either the IDP provided "
-"NameId property is populated with the email address format,\n"
-"                                          or configure the IDP to add the "
-"users email address in the samlResponse claims using\n"
-"                                          the designated schema property key:"
+"PHP-SAML could not initialize the settings object using the configEntity."
 msgstr ""
 
-#: src/LoginFlow/User.php:446
+#: src/LoginFlow/Acs.php:199
+msgid "Samlsso->acs->init->phpsaml->initializeSettings"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:207
+msgid "PHP-SAML library could not process samlResponse and reported the error:"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:208
+msgid "Samlsso->acs->init->phpsaml->initializeResponse"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:227
+#, php-format
 msgid ""
-"Provided firstname or givenname exceeded 255 characters. This claim should "
-"not be longer than 255 characters"
+"Could not fetch loginState from database with error: <br><br>%s<br><br>See: "
+"%s for more information."
 msgstr ""
 
-#: src/LoginFlow/User.php:457
+#: src/LoginFlow/Acs.php:228
+msgid "Samlsso->acs->init->LoginState::construct"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:251
 msgid ""
-"Provided surname claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
+"Validation of the samlResponse document failed. Review the saml log for more "
+"details"
 msgstr ""
 
-#: src/LoginFlow/User.php:470
+#: src/LoginFlow/Acs.php:252 src/LoginFlow/Acs.php:259
+msgid "Samlsso->acs->assertSaml->SamlResponse::isValid"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:258
 msgid ""
-"Provided job title claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
+"Validation of the samlResponse document failed with a critical error. Review "
+"the saml log for more details"
 msgstr ""
 
-#: src/LoginFlow/User.php:483
+#: src/LoginFlow/Acs.php:279
+#, php-format
 msgid ""
-"Provided mobile phone number claim exceeded 255 characters. This claim "
-"should not be longer than 255 characters"
+"It looks like this samlResponse has already been used to authenticate a "
+"different user.\n"
+"                    Maybe an error occurred and you pressed F5 and "
+"accidently resend the samlResponse that is\n"
+"                    already registered as processed. For security reasons we "
+"can not allow processed samlResponses\n"
+"                    to be processed again. Please login again to generate a "
+"new samlResponse. Sorry for any inconvenience.\n"
+"                    If the problem presists, then please contact your "
+"administrator.\n"
+"                    See: %s for more information"
 msgstr ""
 
-#: src/LoginFlow/User.php:496
+#: src/LoginFlow/Acs.php:285
+msgid "Samlsso->acs->assertSaml->LoginState::checkResponseIdUnique"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:306
 msgid ""
-"Provided telephone phone number claim exceeded 255 characters. This claim "
-"should not be longer than 255 characters"
+"An error occured while trying to update the samlResponseId into the "
+"LoginState database. Review the saml log for more details"
 msgstr ""
 
-#: src/LoginFlow/User.php:509
+#: src/LoginFlow/Acs.php:307
+msgid "Samlsso->acs->assertSaml->LoginState::setSamlResponseId"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:320
+#, php-format
 msgid ""
-"Provided country claim exceeded 255 characters. This claim should not be "
-"longer than 255 characters"
+"GLPI did not expect an assertion from this Idp. The most likely reason is a "
+"race condition\n"
+"                    causing an inconsistant loginState in the database or "
+"software bug. Please login again via the\n"
+"                    GLPI-interface. Sorry for the inconvenience. See: %s\n"
+"                    for more information"
 msgstr ""
 
-#: src/LoginFlow/User.php:522
+#: src/LoginFlow/Acs.php:324
+msgid "Samlsso->acs->assertSaml->PhaseMismatched"
+msgstr ""
+
+#: src/LoginFlow/Acs.php:338
 msgid ""
-"Provided city claim exceeded 255 characters. This claim should not be longer "
-"than 255 characters"
+"An error occured while trying to update the login phase to "
+"LoginState::PHASE_SAML_AUTH  into the LoginState database.\n"
+"                                  Review the saml log for more details"
 msgstr ""
 
-#: src/LoginFlow/User.php:535
-msgid ""
-"Provided street address claim exceeded 255 characters. This claim should not "
-"be longer than 255 characters"
+#: src/LoginFlow/Acs.php:339
+msgid "LoginState"
 msgstr ""
 
-#: src/LoginFlow/User.php:546
-msgid "Created by phpSaml Just-In-Time user creation on:"
-msgstr ""
-
-#: src/LoginFlow/LoginFlowForm.php:69
+#: src/LoginFlow/LoginFlowForm.php:71
 msgid "Identity providers"
 msgstr ""
 
-#: src/Exclude.php:124
+#: src/LoginFlow/LoginFlowForm.php:114
+msgid "Configuration invalid please correct all ⭕ errors first"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:120
+msgid "⭕ IDP ID must be a positive numeric value!"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:124
+msgid "What IDP ID should be enforced?"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:125
+msgid "ENFORCED IDP ID"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:144
+msgid "Debug enabled?"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:161
+msgid ""
+"Should SAML SSO be enforced. This option can be bypassed by the bypass var "
+"and value"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:162
+msgid "ENFORCE SSO"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:178
+msgid "Try to match domain in username for IDP selection"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:179
+msgid "ENABLE DOMAIN BASED SSO"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:195
+msgid "Allow the ?idpId=[val] URI to pre select IDP from URLs"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:196
+msgid "Enable getter login"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:212
+msgid ""
+"Hide the default GLPI login options. This option can be bypassed using the "
+"bypass var and value."
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:213
+msgid "HIDE GLPI LOGIN"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:229
+msgid ""
+"Hides Saml Buttons. This option cannot be used together with the Hide GLPI "
+"login."
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:230
+msgid "Hide Saml Buttons"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:246
+msgid "Hide the GLPI password field. To be used with Enable Domain Login."
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:247
+msgid "HIDE PASSWORD FIELD"
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:263
+msgid "Forces samlSSO to (re)apply the rules on each succesfull auth."
+msgstr ""
+
+#: src/LoginFlow/LoginFlowItem.php:264
+msgid "APPLY RULES ON AUTH"
+msgstr ""
+
+#: src/Exclude.php:126
 msgid "samlSSO Excludes"
 msgstr ""
 
-#: src/Exclude.php:146
+#: src/Exclude.php:149
 msgid "Agent contains"
 msgstr ""
 
-#: src/Exclude.php:152
+#: src/Exclude.php:155
 msgid "Bypass SAML auth"
 msgstr ""
 
-#: src/Exclude.php:157
+#: src/Exclude.php:160
 msgid "Url contains path or file"
 msgstr ""
 
-#: src/Exclude.php:179
+#: src/Exclude.php:182
 msgid "Client Agent performing the call"
 msgstr ""
 
-#: src/Exclude.php:188
+#: src/Exclude.php:191
 msgid "To be excluded path"
+msgstr ""
+
+#: src/RuleSaml.php:86
+msgid "JIT rules"
+msgstr ""
+
+#: src/RuleSaml.php:153
+#, php-format
+msgid "SAML Claim: %s"
 msgstr ""

--- a/src/Config/ConfigForm.php
+++ b/src/Config/ConfigForm.php
@@ -568,7 +568,7 @@ HTML;
             }
         }else{
             // Leave an error message and reload the form with provided values and errors
-            Session::addMessageAfterRedirect(__('Configuration invalid please correct all ⭕ errors first', PLUGIN_NAME));
+            Session::addMessageAfterRedirect(__('Configuration invalid, please correct all ⭕ errors first', PLUGIN_NAME));
             $this->displayUIHeader();
             return new Response($this->generateForm($configEntity));
         }

--- a/src/Config/ConfigItem.php
+++ b/src/Config/ConfigItem.php
@@ -350,7 +350,7 @@ class ConfigItem    //NOSONAR
     protected function conf_icon(mixed $var): array                     //NOSONAR
     {
         return [
-            ConfigItem::FORMEXPLAIN => __('The FontAwesome (https://fontawesome.com/) icon to show on the button on the login page.', PLUGIN_NAME),
+            ConfigItem::FORMEXPLAIN => sprintf(__('The FontAwesome (%s) icon to show on the button on the login page.', PLUGIN_NAME), 'https://fontawesome.com/'),
             ConfigItem::FORMTITLE => __('LOGIN ICON', PLUGIN_NAME),
             ConfigItem::EVAL      => ConfigItem::VALID,
             ConfigItem::VALUE     => (string) $var,

--- a/src/LoginFlow/Acs.php
+++ b/src/LoginFlow/Acs.php
@@ -153,7 +153,7 @@ class Acs extends LoginFlow
             $this->assertSaml();
         } else {
             $this->printError(
-                __('The received idp response did not contain the required samlResponse POST body or idpId to authenticate the user, see: https://codeberg.org/QuinQuies/glpisaml/wiki/ACS.php for more information', PLUGIN_NAME),
+                sprintf(__('The received idp response did not contain the required samlResponse POST body or idpId to authenticate the user, see: %s for more information', PLUGIN_NAME), 'https://codeberg.org/QuinQuies/glpisaml/wiki/ACS.php'),
                 __('Samlsso->acs->init->NoSamlResponse', PLUGIN_NAME),
                 Acs::EXTENDED_HEADER .
                     Acs::SERVER_OBJ . var_export($_SERVER, true) . "\n\n" .
@@ -224,7 +224,7 @@ class Acs extends LoginFlow
             // All references to state removed when state doesnt exist yet.
             // Fix for: https://github.com/DonutsNL/samlsso/issues/104
             $this->printError(
-                __("Could not fetch loginState from database with error: <br><br>$e<br><br>See: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php for more information.", PLUGIN_NAME),
+                sprintf(__("Could not fetch loginState from database with error: <br><br>%s<br><br>See: %s for more information.", PLUGIN_NAME), $e, 'https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php'),
                 __('Samlsso->acs->init->LoginState::construct', PLUGIN_NAME)
             );
         }
@@ -276,12 +276,12 @@ class Acs extends LoginFlow
             !$this->state->checkResponseIdUnique($currentResponseId)
         ) {
             $this->printError(
-                __("It looks like this samlResponse has already been used to authenticate a different user.
+                sprintf(__("It looks like this samlResponse has already been used to authenticate a different user.
                     Maybe an error occurred and you pressed F5 and accidently resend the samlResponse that is
                     already registered as processed. For security reasons we can not allow processed samlResponses
                     to be processed again. Please login again to generate a new samlResponse. Sorry for any inconvenience.
                     If the problem presists, then please contact your administrator.
-                    See: https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php for more information", PLUGIN_NAME),
+                    See: %s for more information", PLUGIN_NAME), 'https://codeberg.org/QuinQuies/glpisaml/wiki/LoginState.php'),
                 __('Samlsso->acs->assertSaml->LoginState::checkResponseIdUnique', PLUGIN_NAME),
                 Acs::EXTENDED_HEADER .
                     "samlResponse with registered ID was replayed in acs.php. Possibly the user pressed F5 when encountering
@@ -317,10 +317,10 @@ class Acs extends LoginFlow
         if ($this->state->getPhase() != LoginState::PHASE_SAML_ACS) {
             // Generate error and log state and response into the errorlog.
             $this->printError(
-                __("GLPI did not expect an assertion from this Idp. The most likely reason is a race condition
+                sprintf(__("GLPI did not expect an assertion from this Idp. The most likely reason is a race condition
                     causing an inconsistant loginState in the database or software bug. Please login again via the
-                    GLPI-interface. Sorry for the inconvenience. See: https://github.com/DonutsNL/samlsso/wiki/Unsollicited-%E2%80%90-IdP-initiated-login-flows
-                    for more information", PLUGIN_NAME),
+                    GLPI-interface. Sorry for the inconvenience. See: %s
+                    for more information", PLUGIN_NAME), 'https://github.com/DonutsNL/samlsso/wiki/Unsollicited-%E2%80%90-IdP-initiated-login-flows'),
                 __('Samlsso->acs->assertSaml->PhaseMismatched', PLUGIN_NAME),
                 Acs::EXTENDED_HEADER .
                     __("Unexpected assertion triggered while session was in a different phase then expected (2). This error was triggered by external source

--- a/src/LoginFlow/Meta.php
+++ b/src/LoginFlow/Meta.php
@@ -73,7 +73,7 @@ class Meta
                 $samlSettings = new Settings($configEntity->getPhpSamlConfig());    // Get the samlConfig using the provided ID.
                 if ( !$metadata = $samlSettings->getSPMetadata() ) {                // Get the Serviceprovider metadata.
                     $metadata = self::STAG.                                         // Set error if something is wrong
-                                __("Error fetching spMetedata.",PLUGIN_NAME).
+                                __("Error fetching spMetadata.",PLUGIN_NAME).
                                 self::ETAG;
                 }
             }else{

--- a/tools/generatePot.sh
+++ b/tools/generatePot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #  ------------------------------------------------------------------------
 #  samlSSO
@@ -15,27 +15,30 @@
 # This script requires gettext to be installed.
 # in debian install it via apt install gettext first.
 
-dirplugin="../"
+script_dir=$(cd "$(dirname "$0")" && pwd)
+dirplugin=$(cd "${script_dir}/.." && pwd)
 
 # 1. Extract the version dynamically from setup.php
-VERSION=$(grep "define('PLUGIN_SAMLSSO_VERSION'" ${dirplugin}/setup.php | awk -F "'" '{print $4}')
+VERSION=$(grep "define('PLUGIN_SAMLSSO_VERSION'" "${dirplugin}/setup.php" | awk -F "'" '{print $4}')
 
+# Download GLPI core en_US.po to a temporary directory to exclude its strings
+pathGLPIenUSpo="${dirplugin}/locales/tmp"
+mkdir -p "${pathGLPIenUSpo}"
 
-pathGLPIenUSpo="../../locales/"
-if [ ! -d "$pathGLPIenUSpo" ];then
-    mkdir -p "${pathGLPIenUSpo}"
-fi
+# Download the file, suppressing progress but following redirects
+curl -sL https://raw.githubusercontent.com/glpi-project/glpi/refs/heads/main/locales/en_US.po -o "${pathGLPIenUSpo}/en_US.po"
 
-curl https://raw.githubusercontent.com/glpi-project/glpi/refs/heads/main/locales/en_US.po > "${pathGLPIenUSpo}en_US.po" 
+cd "${dirplugin}" || exit 1
 
-cd $dirplugin
-
-find ./ -type f -name "*.php" | xgettext -f - -o "locales/samlSSO.pot" -L PHP \
+find . -type f -name "*.php" | xgettext -f - -o "locales/samlSSO.pot" -L PHP \
     --package-name="samlSSO" \
     --package-version="${VERSION}" \
     --copyright-holder="Chris Gralike" \
     --msgid-bugs-address="https://github.com/DonutsNL/samlSSO/issues" \
-    --exclude-file="${pathGLPIenUSpo}en_US.po" \
+    --exclude-file="locales/tmp/en_US.po" \
     --from-code=UTF-8 \
     --force-po \
     --keyword=__
+
+# Clean up temporary files
+rm -rf "${pathGLPIenUSpo}"


### PR DESCRIPTION
# Description

## 📝 Summary
This PR addresses translation compilation warnings by safely decoupling embedded URLs from gettext strings, significantly improves the robustness of the `generatePot.sh` script to ensure it's completely POSIX compliant, and introduces full support for Portuguese-Brazil (`pt_BR`) translations.

## 🛠️ Changes Made
* **i18n String Refactoring**:
  * Fixed `xgettext` warnings about embedded URLs in translatable strings within `src/Config/ConfigItem.php` and `src/LoginFlow/Acs.php`. These URLs are now dynamically injected using `sprintf()`.
* **Script Refactoring (`tools/generatePot.sh`)**:
  * Swapped the shebang from `#!/bin/bash` to `#!/bin/sh` for broader POSIX compatibility.
  * Resolved fragile `$PWD` and `../` pathing. The script now dynamically determines its own directory (`dirname "$0"`), meaning it can be safely executed from anywhere.
  * Fixed the download location for the GLPI core `en_US.po` file. Previously, it leaked into `../../locales/`, which caused `xgettext` to error during standalone development. It now isolates the download to a local `locales/tmp` folder and cleans it up once finished.
* **Translation Sync**:
  * Successfully regenerated `locales/samlSSO.pot`.
  * Included a complete Portuguese-Brazil (`pt_BR`) translation.
  * Merged the updated string catalog cleanly into `es_AR.po` and `pt_BR.po` using `msgmerge`.

## 🧪 How to Test
1. From anywhere in your terminal, run the script: `/path/to/samlsso/tools/generatePot.sh`.
2. Confirm the script executes without throwing any `No such file or directory` or `warning: Message contains an embedded URL` errors.
3. Validate that the `locales/samlSSO.pot` is updated with the new `sprintf` structure (e.g., look for the `%s` substitutions instead of raw URLs).
4. Verify the newly provided Portuguese-Brazil translations in `locales/pt_BR.po` function correctly within the application interface.
