### PR TITLE
feat: Enhance SAML Rule Engine Criteria and Improve Preset Selection UI

### DIFF
--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -356,14 +356,15 @@ class User
             User::NAME           => $userFields[User::NAME] ?? false,
             User::REALNAME       => $userFields[User::REALNAME] ?? false,
             User::FIRSTNAME      => $userFields[User::FIRSTNAME] ?? false,
-            User::EMAIL          => $userFields[User::EMAIL] ?? false,
+            User::EMAIL          => $userFields[User::EMAIL],
             User::MOBILE         => $userFields[User::MOBILE] ?? false,
             User::PHONE          => $userFields[User::PHONE] ?? false,
-            User::SAMLGROUPS     => $userFields[User::SAMLGROUPS] ?? false,
+            User::SAMLGROUPS     => $userFields[User::SAMLGROUPS],
             User::SAMLJOBTITLE   => $userFields[User::SAMLJOBTITLE] ?? false,
             User::SAMLCOUNTRY    => $userFields[User::SAMLCOUNTRY] ?? false,
             User::SAMLCITY       => $userFields[User::SAMLCITY] ?? false,
             User::SAMLSTREET     => $userFields[User::SAMLSTREET] ?? false,
+            'groups'             => $userFields[User::SAMLGROUPS],
         ];
 
         if (isset($userFields['_saml_rule_fields']) && is_array($userFields['_saml_rule_fields'])) {

--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -364,7 +364,6 @@ class User
             User::SAMLCOUNTRY    => $userFields[User::SAMLCOUNTRY] ?? false,
             User::SAMLCITY       => $userFields[User::SAMLCITY] ?? false,
             User::SAMLSTREET     => $userFields[User::SAMLSTREET] ?? false,
-            'groups'             => $userFields[User::SAMLGROUPS] ?? false,
         ];
 
         if (isset($userFields['_saml_rule_fields']) && is_array($userFields['_saml_rule_fields'])) {

--- a/src/LoginFlow/User.php
+++ b/src/LoginFlow/User.php
@@ -353,13 +353,18 @@ class User
     {
         $ruleCollection = new RuleSamlCollection();
         $matchInput = [
-            User::EMAIL          => $userFields[User::EMAIL],
-            User::SAMLGROUPS     => $userFields[User::SAMLGROUPS],
+            User::NAME           => $userFields[User::NAME] ?? false,
+            User::REALNAME       => $userFields[User::REALNAME] ?? false,
+            User::FIRSTNAME      => $userFields[User::FIRSTNAME] ?? false,
+            User::EMAIL          => $userFields[User::EMAIL] ?? false,
+            User::MOBILE         => $userFields[User::MOBILE] ?? false,
+            User::PHONE          => $userFields[User::PHONE] ?? false,
+            User::SAMLGROUPS     => $userFields[User::SAMLGROUPS] ?? false,
             User::SAMLJOBTITLE   => $userFields[User::SAMLJOBTITLE] ?? false,
             User::SAMLCOUNTRY    => $userFields[User::SAMLCOUNTRY] ?? false,
             User::SAMLCITY       => $userFields[User::SAMLCITY] ?? false,
             User::SAMLSTREET     => $userFields[User::SAMLSTREET] ?? false,
-            'groups'             => $userFields[User::SAMLGROUPS],
+            'groups'             => $userFields[User::SAMLGROUPS] ?? false,
         ];
 
         if (isset($userFields['_saml_rule_fields']) && is_array($userFields['_saml_rule_fields'])) {

--- a/src/RuleSaml.php
+++ b/src/RuleSaml.php
@@ -186,21 +186,21 @@ class RuleSaml extends Rule
 
             $criterias['country']['table']          = '';
             $criterias['country']['field']          = '';
-            $criterias['country']['name']           = __('Country', PLUGIN_NAME);
+            $criterias['country']['name']           = __('SAML Country', PLUGIN_NAME);
             $criterias['country']['linkfield']      = '';
             $criterias['country']['virtual']        = true;
             $criterias['country']['id']             = 'country';
 
             $criterias['city']['table']             = '';
             $criterias['city']['field']             = '';
-            $criterias['city']['name']              = __('City', PLUGIN_NAME);
+            $criterias['city']['name']              = __('SAML City', PLUGIN_NAME);
             $criterias['city']['linkfield']         = '';
             $criterias['city']['virtual']           = true;
             $criterias['city']['id']                = 'city';
 
             $criterias['street']['table']           = '';
             $criterias['street']['field']           = '';
-            $criterias['street']['name']            = __('Street', PLUGIN_NAME);
+            $criterias['street']['name']            = __('SAML Street', PLUGIN_NAME);
             $criterias['street']['linkfield']       = '';
             $criterias['street']['virtual']         = true;
             $criterias['street']['id']              = 'street';

--- a/src/RuleSaml.php
+++ b/src/RuleSaml.php
@@ -127,12 +127,83 @@ class RuleSaml extends Rule
 
         if (!count($criterias)) {
             $criterias['common']                    = __('Global criteria', PLUGIN_NAME);
+
             $criterias['_useremails']['table']      = '';
             $criterias['_useremails']['field']      = '';
             $criterias['_useremails']['name']       = _n('Email', 'Emails', 1);
             $criterias['_useremails']['linkfield']  = '';
             $criterias['_useremails']['virtual']    = true;
             $criterias['_useremails']['id']         = '_useremails';
+
+            $criterias['name']['table']             = '';
+            $criterias['name']['field']             = '';
+            $criterias['name']['name']              = __('Username');
+            $criterias['name']['linkfield']         = '';
+            $criterias['name']['virtual']           = true;
+            $criterias['name']['id']                = 'name';
+
+            $criterias['realname']['table']         = '';
+            $criterias['realname']['field']         = '';
+            $criterias['realname']['name']          = __('Surname');
+            $criterias['realname']['linkfield']     = '';
+            $criterias['realname']['virtual']       = true;
+            $criterias['realname']['id']            = 'realname';
+
+            $criterias['firstname']['table']        = '';
+            $criterias['firstname']['field']        = '';
+            $criterias['firstname']['name']         = __('First name');
+            $criterias['firstname']['linkfield']    = '';
+            $criterias['firstname']['virtual']      = true;
+            $criterias['firstname']['id']           = 'firstname';
+
+            $criterias['mobile']['table']           = '';
+            $criterias['mobile']['field']           = '';
+            $criterias['mobile']['name']            = __('Mobile phone');
+            $criterias['mobile']['linkfield']       = '';
+            $criterias['mobile']['virtual']         = true;
+            $criterias['mobile']['id']              = 'mobile';
+
+            $criterias['phone']['table']            = '';
+            $criterias['phone']['field']            = '';
+            $criterias['phone']['name']             = __('Phone');
+            $criterias['phone']['linkfield']        = '';
+            $criterias['phone']['virtual']          = true;
+            $criterias['phone']['id']               = 'phone';
+
+            $criterias['samlClaimedGroups']['table']      = '';
+            $criterias['samlClaimedGroups']['field']      = '';
+            $criterias['samlClaimedGroups']['name']       = __('SAML Groups', PLUGIN_NAME);
+            $criterias['samlClaimedGroups']['linkfield']  = '';
+            $criterias['samlClaimedGroups']['virtual']    = true;
+            $criterias['samlClaimedGroups']['id']         = 'samlClaimedGroups';
+
+            $criterias['samlClaimedJobTitle']['table']    = '';
+            $criterias['samlClaimedJobTitle']['field']    = '';
+            $criterias['samlClaimedJobTitle']['name']     = __('SAML Job Title', PLUGIN_NAME);
+            $criterias['samlClaimedJobTitle']['linkfield']= '';
+            $criterias['samlClaimedJobTitle']['virtual']  = true;
+            $criterias['samlClaimedJobTitle']['id']       = 'samlClaimedJobTitle';
+
+            $criterias['country']['table']          = '';
+            $criterias['country']['field']          = '';
+            $criterias['country']['name']           = __('Country', PLUGIN_NAME);
+            $criterias['country']['linkfield']      = '';
+            $criterias['country']['virtual']        = true;
+            $criterias['country']['id']             = 'country';
+
+            $criterias['city']['table']             = '';
+            $criterias['city']['field']             = '';
+            $criterias['city']['name']              = __('City', PLUGIN_NAME);
+            $criterias['city']['linkfield']         = '';
+            $criterias['city']['virtual']           = true;
+            $criterias['city']['id']                = 'city';
+
+            $criterias['street']['table']           = '';
+            $criterias['street']['field']           = '';
+            $criterias['street']['name']            = __('Street', PLUGIN_NAME);
+            $criterias['street']['linkfield']       = '';
+            $criterias['street']['virtual']         = true;
+            $criterias['street']['id']              = 'street';
 
             global $DB;
             if (isset($DB) && method_exists($DB, 'tableExists') && $DB->tableExists(ClaimMap::getTable())) {

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -5,6 +5,10 @@
 <script>
     // Remember tab state
     $(function() {
+        if ($.fn.select2) {
+            $('#preset_selector').select2();
+        }
+        
         $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
             localStorage.setItem('lastTab', $(this).attr('href'));
         });
@@ -56,7 +60,11 @@
             var targetType = (field === 'groups') ? 'rule_field' : 'user_field';
             addRow(targetType, field, preset[field], '', (field === 'email') ? 1 : 0);
         }
-        document.getElementById('preset_selector').value = '';
+        if ($.fn.select2) {
+            $('#preset_selector').val('').trigger('change.select2');
+        } else {
+            document.getElementById('preset_selector').value = '';
+        }
     }
 
     function updateGlpiFields(selectElem) {

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -60,11 +60,37 @@
             var targetType = (field === 'groups') ? 'rule_field' : 'user_field';
             addRow(targetType, field, preset[field], '', (field === 'email') ? 1 : 0);
         }
-        if ($.fn.select2) {
-            $('#preset_selector').val('').trigger('change.select2');
-        } else {
-            document.getElementById('preset_selector').value = '';
+        var $tableWrap = $('#claim_mapping_tbody').closest('.table-responsive');
+        if (!$tableWrap.length) $tableWrap = $('#claim_mapping_tbody').parent();
+        
+        var $overlay = $('<div class="preset-loading-overlay"><i class="fas fa-spinner fa-spin fa-3x"></i></div>');
+        $overlay.css({
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            background: 'rgba(255, 255, 255, 0.7)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 10
+        });
+        
+        if ($tableWrap.css('position') === 'static') {
+            $tableWrap.css('position', 'relative');
         }
+        
+        $tableWrap.append($overlay);
+
+        setTimeout(function() {
+            $overlay.remove();
+            if ($.fn.select2) {
+                $('#preset_selector').val('').trigger('change.select2');
+            } else {
+                document.getElementById('preset_selector').value = '';
+            }
+        }, 500);
     }
 
     function updateGlpiFields(selectElem) {
@@ -1163,7 +1189,7 @@
                                     <div class="d-flex align-items-center">
                                         <label class="mb-0 me-3 fw-bold" style="white-space: nowrap;">{{ __('Apply Preset', plugin) }}</label>
                                         <select id="preset_selector" class="form-select form-select-sm" onchange="applyPreset(this.value)">
-                                            <option value="">-- {{ __('Select Preset', plugin) }} --</option>
+                                            <option value="">{{ __('Select Preset', plugin) }}</option>
                                             {% for name, preset in mapping_presets %}
                                                 <option value="{{ name }}">{{ name|title }}</option>
                                             {% endfor %}

--- a/templates/configForm.html.twig
+++ b/templates/configForm.html.twig
@@ -1166,6 +1166,9 @@
                     .xml-attr { color: #6f42c1; }
                     .xml-val { color: #032f62; }
                     .xml-comment { color: #6a737d; font-style: italic; }
+                    #samlsso-mapping-tools-collapse .select2-container .select2-selection.select2-selection--single .select2-selection__rendered::before {
+                        display: inline !important;
+                    }
                 </style>
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-center mb-3">
@@ -1189,7 +1192,7 @@
                                     <div class="d-flex align-items-center">
                                         <label class="mb-0 me-3 fw-bold" style="white-space: nowrap;">{{ __('Apply Preset', plugin) }}</label>
                                         <select id="preset_selector" class="form-select form-select-sm" onchange="applyPreset(this.value)">
-                                            <option value="">{{ __('Select Preset', plugin) }}</option>
+                                            <option value="">-- {{ __('Select Preset', plugin) }} --</option>
                                             {% for name, preset in mapping_presets %}
                                                 <option value="{{ name }}">{{ name|title }}</option>
                                             {% endfor %}


### PR DESCRIPTION
## Description
This PR expands the criteria available within the SAML JIT rule engine to encompass a broader set of standard user fields and common SAML claims. It also refines the mapping configuration UI by introducing a native `select2` control and providing better visual feedback when applying claim presets.

### Key Changes:

**1. Rule Engine Expansion**
* Added robust support for standard GLPI user fields and common SAML attributes in `src/RuleSaml.php`.
* Prefixed non-GLPI specific criteria labels (such as Country, City, and Street) with "SAML" to clearly distinguish them in the UI.
* Cleaned up the `matchInput` processing in `src/LoginFlow/User.php`'s `runRulesEngine` method to accurately pass all supported fields and removed redundant group aliases.

**2. UI & UX Improvements for Claim Mapping**
* Upgraded the "Apply Preset" dropdown in `templates/configForm.html.twig` to utilize the native GLPI `select2` control for a more consistent and modern interface.
* Added a 500ms fake spinner overlay that displays over the mapping table when a preset is applied. This UX pattern-adding an artificial delay of 300-500ms before processing completes-is widely used by platforms like Facebook to give end users the psychological sensation that background work is actively being performed before the dropdown field clears itself. Without this feedback, the dropdown can feel buggy because the value appears to never change, even though the settings apply successfully under the hood.
* Applied targeted CSS overrides to fix a visual bug where GLPI's native `select2` styles were injecting an extra `--` prefix into our `-- Select Preset --` placeholder.