### PR TITLE
Recover timed-out SAML session instead of locking it out

### DIFF
--- a/src/LoginFlow/Acs.php
+++ b/src/LoginFlow/Acs.php
@@ -261,6 +261,20 @@ class Acs extends LoginFlow
             );
         }
 
+        // samlSSO fix: recover a timed-out session instead of rejecting it.
+        // When a session previously timed out (PHASE_TIMED_OUT) the user usually
+        // retries from the same browser. A fresh, UNIQUE samlResponse must then be
+        // treated as a new attempt, not a replay/race. Without this, the phase gates
+        // below ("already used to authenticate a different user" and PhaseMismatched)
+        // reject every retry, permanently locking the session out: the session GC
+        // (cronCleanSessionSAML) keys on lastActivity, which each rejected retry
+        // refreshes, so the dead state never reaches its retention age. Genuine replays
+        // stay blocked by getSamlResponseId()/checkResponseIdUnique(); a timed-out
+        // state is by definition not an in-flight parallel request.
+        if ($this->state->getPhase() === LoginState::PHASE_TIMED_OUT) {
+            $this->state->setPhase(LoginState::PHASE_SAML_ACS);
+        }
+
         // Prevent replay attacks, check if response_id is already used
         // The response_id is unique and should only be processed once.
         // This is checked by comparing the response_id from the incoming


### PR DESCRIPTION
## Problem

After a SAML login attempt times out, the `LoginState` is set to `PHASE_TIMED_OUT (7)`. On the **next** attempt from the same browser session, a fresh, valid, **unique** `samlResponse` arriving at the ACS is rejected as a replay:

> It looks like this samlResponse has already been used to authenticate a different user.

The session never recovers on its own, so the user is locked out **indefinitely** (an admin has to delete the row manually).

## Root cause

The two post-validation guards in `Acs.php` require the state to be `PHASE_SAML_ACS`:

```php
// guard 1 — "replay"
if ( empty($currentResponseId)
  || $this->state->getPhase() != LoginState::PHASE_SAML_ACS   // <-- fires for TIMED_OUT
  || !empty($this->state->getSamlResponseId())
  || !$this->state->checkResponseIdUnique($currentResponseId) ) { ... }

// guard 2 — "PhaseMismatched"
if ($this->state->getPhase() != LoginState::PHASE_SAML_ACS) { ... }
```

A timed-out state is `PHASE_TIMED_OUT`, so the **phase** sub-condition trips guard 1 even though `responseId` is genuinely new and unique. The state is never reset on a retry.

### Why it's permanent

`CronTask::cronCleanSessionSAML()` deletes states older than `param` days (default 30) based on **`LAST_ACTIVITY`**. Each rejected retry calls `setLastActivity()`, refreshing it, so the dead `PHASE_TIMED_OUT` row never reaches its retention age → it is never cleaned → permanent lockout. Shared/kiosk accounts that retry often are hit hardest.

## Reproduction

1. Start a SAML login, then let it exceed `REQUEST_TIMEOUT` (state becomes `PHASE_TIMED_OUT`).
2. From the same browser session, log in again with a fresh, valid assertion.
3. Observe the "already been used to authenticate a different user" error; repeating only refreshes `lastActivity` and the lockout persists.

## Fix

Before the guards, treat a `PHASE_TIMED_OUT` state as a fresh attempt by resetting it to `PHASE_SAML_ACS`.

### Why this does not weaken security

- **Replay** is still fully blocked by `getSamlResponseId()` (slot already filled) and `checkResponseIdUnique()` (id already processed) — both run unchanged after the reset. A duplicate `responseId` is still rejected.
- **Race conditions** are unaffected: a `PHASE_TIMED_OUT` state is by definition *not* an in-flight `PHASE_SAML_ACS` request — it already exceeded the timeout window.
- Only the false-positive (timed-out → legitimate retry) path changes.

### Tested

I verified the guard logic with a standalone PHP harness (bug reproduced unpatched; fixed when patched; replay / empty-id / initial-phase / race cases still rejected; normal login unaffected). Happy to contribute it as a proper test under `tests/` in your style if useful.

### Optional deeper hardening

Replay protection and audit retention share one table but have opposite lifetimes. Consider purging **incomplete** states (`glpiAuthed = 0`) by `loginTime` after minutes, while keeping completed states for the 30-day audit window — so a dead session can never block a login regardless of retries.
