### PR TITLE
fix: support GeneralizedTime X.509 certificate dates 

### DIFF
--- a/src/Config/ConfigItem.php
+++ b/src/Config/ConfigItem.php
@@ -802,29 +802,30 @@ class ConfigItem    //NOSONAR
             if (($parsedCertificate = openssl_x509_parse($certificate))) {
                 // Create time object from current timestamp to calculate with
                 $n = new DateTimeImmutable('now');
-                // Create time object from validTo certificate property
-                $t = (array_key_exists('validTo', $parsedCertificate)) ? DateTimeImmutable::createFromFormat("ymdHisT", $parsedCertificate['validTo']) : '';
-                // Create time object from validFrom certificate property
-                $f = (array_key_exists('validFrom', $parsedCertificate)) ? DateTimeImmutable::createFromFormat("ymdHisT", $parsedCertificate['validFrom']) : '';
-                // Calculate if the current date is past the validTo certificate property
-                $aged = $n->diff($t);
-                // Format the age to days between.
-                $aged = $aged->format('%R%a');
-                // Calculate if the current date is before the validFrom certificate property.
-                $born = $f->diff($n);
-                // Format the born date to days between.
-                $born = $born->format('%R%a');
+                // Create time objects from certificate validity properties.
+                $t = $this->createCertificateDateTime($parsedCertificate, 'validTo');
+                $f = $this->createCertificateDateTime($parsedCertificate, 'validFrom');
                 // Get the certificate's common name property.
                 /** @var array $subject */
                 $subject = $parsedCertificate['subject'];
-                $cn = $subject['CN'];
-                // Validate if we got a negative sign in the calculated ValidTo days.
-                if (strpos($aged, '-') !== false) {
-                    $validations['validTo'] = sprintf(__("⚠️ Warning, certificate with Common Name (CN): %s is expired: %s days", PLUGIN_NAME), $cn, $aged);
+                $cn = (string)($subject['CN'] ?? '');
+                if ($t instanceof DateTimeImmutable) {
+                    // Calculate if the current date is past the validTo certificate property.
+                    $aged = $n->diff($t)->format('%R%a');
+                    if (strpos($aged, '-') !== false) {
+                        $validations['validTo'] = sprintf(__("⚠️ Warning, certificate with Common Name (CN): %s is expired: %s days", PLUGIN_NAME), $cn, $aged);
+                    }
+                } else {
+                    $validations['validTo'] = __('⭕ Unable to parse certificate validTo date', PLUGIN_NAME);
                 }
-                // Validate if we got a negative sign in the calculated validFrom days.
-                if (strpos($born, '-') !== false) {
-                    $validations['validFrom'] = sprintf(__("⚠️ Warning, certificate with Common Name (CN): %s issued in the future (%s days)", PLUGIN_NAME), $cn, $born);
+                if ($f instanceof DateTimeImmutable) {
+                    // Calculate if the current date is before the validFrom certificate property.
+                    $born = $f->diff($n)->format('%R%a');
+                    if (strpos($born, '-') !== false) {
+                        $validations['validFrom'] = sprintf(__("⚠️ Warning, certificate with Common Name (CN): %s issued in the future (%s days)", PLUGIN_NAME), $cn, $born);
+                    }
+                } else {
+                    $validations['validFrom'] = __('⭕ Unable to parse certificate validFrom date', PLUGIN_NAME);
                 }
                 if ($cn == 'withlove.from.donuts.nl') {
                     $validations['validFrom'] = __("⚠️ Warning, do not use the 'withlove.from.donuts.nl' example certificates. They offer no additional protection.", PLUGIN_NAME);
@@ -851,6 +852,27 @@ class ConfigItem    //NOSONAR
         }
         // Return message OpenSSL is not available.
         return ['validations'   => __('⚠️ OpenSSL is not available, GLPI cant validate your certificate', PLUGIN_NAME)];
+    }
+
+    private function createCertificateDateTime(array $parsedCertificate, string $field): ?DateTimeImmutable
+    {
+        $timestampField = $field . '_time_t';
+        if (isset($parsedCertificate[$timestampField]) && is_numeric($parsedCertificate[$timestampField])) {
+            return (new DateTimeImmutable())->setTimestamp((int)$parsedCertificate[$timestampField]);
+        }
+
+        if (empty($parsedCertificate[$field]) || !is_string($parsedCertificate[$field])) {
+            return null;
+        }
+
+        foreach (['ymdHisT', 'YmdHisT'] as $format) {
+            $date = DateTimeImmutable::createFromFormat($format, $parsedCertificate[$field]);
+            if ($date instanceof DateTimeImmutable) {
+                return $date;
+            }
+        }
+
+        return null;
     }
 
     protected function validateCertKeyPairModulus(string $certificate, string $privateKey): bool         //NOSONAR - Maybe fix complexity in the future

--- a/tests/CertValidationTest.php
+++ b/tests/CertValidationTest.php
@@ -112,6 +112,37 @@ namespace GlpiPlugin\Samlsso\Tests {
         }
 
         /**
+         * Returns an IdP certificate whose validTo value is represented by
+         * OpenSSL as GeneralizedTime because the expiry year is 2050.
+         *
+         * @return string Pem encoded certificate.
+         */
+        private function getGeneralizedTimeCert(): string {
+            return <<<'CERT'
+-----BEGIN CERTIFICATE-----
+MIIDVTCCAj2gAwIBAgIUHWkLB0XI93oWDdwAwHWLur8/L4IwDQYJKoZIhvcNAQEL
+BQAwOTELMAkGA1UEBhMCWloxEDAOBgNVBAoMB0V4YW1wbGUxGDAWBgNVBAMMD2lk
+cC5leGFtcGxlLmNvbTAgFw0yNjA2MjkxMzMwNDVaGA8yMDUwMDYyOTEzMzA0NVow
+OTELMAkGA1UEBhMCWloxEDAOBgNVBAoMB0V4YW1wbGUxGDAWBgNVBAMMD2lkcC5l
+eGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMo2NVs2
+1mp0bSWKIGoOXIAb9tyvPUFpYTkYhoBhYUvWwTebWJGx+ectc3p4dauKOlMCbuNK
+vFT09IeMIURZD+Lk/iVye8b22X4vspcyADj6mG3XMyPMBZJEo/PuNdvWRYfxO2oV
+O72Qtf0Xmr3G7iN1Ug0OAAKyDULUQZvEcoq1q3V59vUqQMeEDbm5+IXRwP/snaCD
+KWLKQCZSuD+16QfISMDWcMQpq9DIwFoQZVZ1O31Oprl6OzzJMTnBFdlUSEIYAkOR
+85KVuCLaF5cuZpN8BfacVR1ld/edkNwFJ5SWFhPCWifqGO63WFsfvdeKkMs0uMG4
+LXOg8ju7lPh+oyECAwEAAaNTMFEwHQYDVR0OBBYEFE20FudzZkRUk3wc6pPIr9p6
+1AxMMB8GA1UdIwQYMBaAFE20FudzZkRUk3wc6pPIr9p61AxMMA8GA1UdEwEB/wQF
+MAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJN0IHjFSME+utsgymY+ODXJzZvwzpRc
+tfaYZKY2J2TmpaKccrMYWmGi38UyJYq8Lxqe8wHvEQAegJGejqA+NdhFidLAVshR
+Ur1GpR4NtKpE3/2ghQ78jrBmPM1reLv82A2Hqi2NaLjt9AsOdNofaf5LAUG5G5Is
+rwFkfQ7J6sQKhbbvGxAWn9H+aA0uueoNMd4KSW7vSqXsRx4p21ExDnLoGCqksqjm
+1/wIWWFnWT9uvqR6ufN3LlxpyQkRKyAG6r63GO7zLouHxgk+PzoP17apUHF7kvuK
+kZwRN56BOwZzX3NO6AxOZWfm223o5LtDT58by1Ib7V+CLYYqIVfyDfU=
+-----END CERTIFICATE-----
+CERT;
+        }
+
+        /**
          * Test that a valid x509 certificate string is successfully parsed.
          *
          * @throws \Exception if the valid certificate is rejected.
@@ -128,6 +159,27 @@ namespace GlpiPlugin\Samlsso\Tests {
                 throw new \Exception("Valid certificate missing 'validations' array.");
             }
             echo "✅ Valid X509 certificate parsing\n";
+        }
+
+        /**
+         * Test that a certificate expiring in 2050 parses without validTo errors.
+         *
+         * @throws \Exception if GeneralizedTime validity dates are rejected.
+         */
+        public function testGeneralizedTimeCertificate(): void {
+            $configItem = new TestableConfigItem();
+            $result = $configItem->testParseX509Certificate($this->getGeneralizedTimeCert());
+
+            if ($result === false) {
+                throw new \Exception("GeneralizedTime certificate rejected.");
+            }
+            if (($result['subject']['CN'] ?? '') !== 'idp.example.com') {
+                throw new \Exception("GeneralizedTime certificate subject was not parsed.");
+            }
+            if (!empty($result['validations'])) {
+                throw new \Exception("GeneralizedTime certificate produced validation errors: " . print_r($result['validations'], true));
+            }
+            echo "✅ GeneralizedTime X509 certificate parsing\n";
         }
 
         /**
@@ -181,6 +233,7 @@ namespace {
     $test = new GlpiPlugin\Samlsso\Tests\CertValidationTest();
     try {
         $test->testValidCertificate();
+        $test->testGeneralizedTimeCertificate();
         $test->testMalformedCertificate();
         if (function_exists('openssl_pkey_new')) {
             $test->testModulusMatching();


### PR DESCRIPTION
with validity dates beyond 2049

I rebased the fix onto the 1.3.2 branch